### PR TITLE
Fix allOf decoding issue

### DIFF
--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -159,7 +159,7 @@ struct Property {
     // A nested declaration required used as a property type
     var nested: Declaration?
     // If the schema is inlined by `allOf`. This is currently used only for the generation of decoders.
-    var isInlined: Bool
+    var isInlined: Bool?
 }
 
 protocol Declaration {

--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -90,8 +90,7 @@ indirect enum TypeIdentifier: CustomStringConvertible, Hashable {
         switch self {
         case .array(let element): return "[\(element)]"
         case .dictionary(let key, let value): return "[\(key): \(value)]"
-        case .userDefined(let name): return name.rawValue
-        case .builtin(let name): return name.rawValue
+        case .userDefined(let name), .builtin(let name): return name.rawValue
         }
     }
 }
@@ -159,6 +158,8 @@ struct Property {
     var metadata: DeclarationMetadata?
     // A nested declaration required used as a property type
     var nested: Declaration?
+    // If the schema is inlined by `allOf`. This is currently used only for the generation of decoders.
+    var isInlined: Bool
 }
 
 protocol Declaration {

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -80,13 +80,8 @@ extension Generator {
             case .allOf:
                 var needsValues = false
                 let decoderContents = properties.map {
-                    if case .userDefined = $0.type {
-                        if $0.isInlined ?? false {
-                            needsValues = true
-                            return templates.decode(property: $0, isUsingCodingKeys: false)
-                        } else {
-                            return templates.decodeFromDecoder(property: $0)
-                        }
+                    if case .userDefined = $0.type, $0.isInlined != true {
+                        return templates.decodeFromDecoder(property: $0)
                     } else {
                         needsValues = true
                         return templates.decode(property: $0, isUsingCodingKeys: false)

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -81,7 +81,7 @@ extension Generator {
                 var needsValues = false
                 let decoderContents = properties.map {
                     if case .userDefined = $0.type {
-                        if $0.isInlined {
+                        if $0.isInlined ?? false {
                             needsValues = true
                             return templates.decode(property: $0, isUsingCodingKeys: false)
                         } else {

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -81,7 +81,12 @@ extension Generator {
                 var needsValues = false
                 let decoderContents = properties.map {
                     if case .userDefined = $0.type {
-                        return templates.decodeFromDecoder(property: $0)
+                        if $0.isInlined {
+                            needsValues = true
+                            return templates.decode(property: $0, isUsingCodingKeys: false)
+                        } else {
+                            return templates.decodeFromDecoder(property: $0)
+                        }
                     } else {
                         needsValues = true
                         return templates.decode(property: $0, isUsingCodingKeys: false)

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -661,7 +661,7 @@ extension Generator {
     
     // MARK: - Property
     
-    func makeProperty(key: String, schema: JSONSchema, isRequired: Bool, in context: Context, isInlined: Bool = false) throws -> Property {
+    func makeProperty(key: String, schema: JSONSchema, isRequired: Bool, in context: Context, isInlined: Bool? = nil) throws -> Property {
         let propertyName: PropertyName
 
         /**

--- a/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
@@ -271,10 +271,10 @@ import NaiveDate
 }
 
  struct Image: Codable {
-    var id: AnyJSON
-    var url: AnyJSON
+    var id: String
+    var url: String
 
-    init(id: AnyJSON, url: AnyJSON) {
+    init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
@@ -209,22 +209,26 @@ import NaiveDate
  struct Dog: Codable {
     var animal: Animal
     var breed: String?
+    var image: Image?
 
-    init(animal: Animal, breed: String? = nil) {
+    init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -257,6 +261,16 @@ import NaiveDate
     init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+ struct Image: Codable {
+    var id: AnyJSON
+    var url: AnyJSON
+
+    init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
@@ -208,10 +208,16 @@ import NaiveDate
 
  struct Dog: Codable {
     var animal: Animal
-    var breed: String?
+    var breed: Breed?
     var image: Image?
 
-    init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -220,7 +226,7 @@ import NaiveDate
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
@@ -310,10 +310,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -322,7 +328,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
@@ -311,22 +311,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -371,6 +375,28 @@ public struct Animal: Codable {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(className, forKey: "className")
         try values.encodeIfPresent(color, forKey: "color")
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: StringCodingKey.self)
+        self.id = try values.decode(AnyJSON.self, forKey: "id")
+        self.url = try values.decode(AnyJSON.self, forKey: "url")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: StringCodingKey.self)
+        try values.encode(id, forKey: "id")
+        try values.encode(url, forKey: "url")
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
@@ -385,18 +385,18 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.id = try values.decode(AnyJSON.self, forKey: "id")
-        self.url = try values.decode(AnyJSON.self, forKey: "url")
+        self.id = try values.decode(String.self, forKey: "id")
+        self.url = try values.decode(String.self, forKey: "url")
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
@@ -209,22 +209,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -257,6 +261,16 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
@@ -271,10 +271,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
@@ -208,10 +208,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -220,7 +226,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
@@ -200,22 +200,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -248,6 +252,16 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
@@ -199,10 +199,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -211,7 +217,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
@@ -262,10 +262,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
@@ -195,22 +195,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -243,6 +247,16 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
@@ -251,10 +251,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
@@ -208,10 +208,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
   public var animal: Animal
-  public var breed: String?
+  public var breed: Breed?
   public var image: Image?
 
-  public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+  public enum Breed: String, Codable, CaseIterable {
+    case large = "Large"
+    case medium = "Medium"
+    case small = "Small"
+  }
+
+  public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
     self.animal = animal
     self.breed = breed
     self.image = image
@@ -220,7 +226,7 @@ public struct Dog: Codable {
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: StringCodingKey.self)
     self.animal = try Animal(from: decoder)
-    self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+    self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
     self.image = try values.decodeIfPresent(Image.self, forKey: "image")
   }
 

--- a/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
@@ -271,10 +271,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-  public var id: AnyJSON
-  public var url: AnyJSON
+  public var id: String
+  public var url: String
 
-  public init(id: AnyJSON, url: AnyJSON) {
+  public init(id: String, url: String) {
     self.id = id
     self.url = url
   }

--- a/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
@@ -209,22 +209,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
   public var animal: Animal
   public var breed: String?
+  public var image: Image?
 
-  public init(animal: Animal, breed: String? = nil) {
+  public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
     self.animal = animal
     self.breed = breed
+    self.image = image
   }
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: StringCodingKey.self)
     self.animal = try Animal(from: decoder)
     self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+    self.image = try values.decodeIfPresent(Image.self, forKey: "image")
   }
 
   public func encode(to encoder: Encoder) throws {
     var values = encoder.container(keyedBy: StringCodingKey.self)
     try values.encode(animal, forKey: "animal")
     try values.encodeIfPresent(breed, forKey: "breed")
+    try values.encodeIfPresent(image, forKey: "image")
   }
 }
 
@@ -257,6 +261,16 @@ public struct Animal: Codable {
   public init(className: String, color: String? = nil) {
     self.className = className
     self.color = color
+  }
+}
+
+public struct Image: Codable {
+  public var id: AnyJSON
+  public var url: AnyJSON
+
+  public init(id: AnyJSON, url: AnyJSON) {
+    self.id = id
+    self.url = url
   }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
@@ -209,22 +209,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -257,6 +261,16 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
@@ -271,10 +271,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
@@ -208,10 +208,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -220,7 +226,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
@@ -229,10 +229,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -241,7 +247,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
@@ -230,22 +230,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -278,6 +282,21 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var identifier: AnyJSON
+    public var url: AnyJSON
+
+    public init(identifier: AnyJSON, url: AnyJSON) {
+        self.identifier = identifier
+        self.url = url
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
@@ -292,10 +292,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var identifier: AnyJSON
-    public var url: AnyJSON
+    public var identifier: String
+    public var url: String
 
-    public init(identifier: AnyJSON, url: AnyJSON) {
+    public init(identifier: String, url: String) {
         self.identifier = identifier
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
@@ -209,22 +209,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -257,6 +261,16 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var id: AnyJSON
+    public var url: AnyJSON
+
+    public init(id: AnyJSON, url: AnyJSON) {
+        self.id = id
+        self.url = url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
@@ -271,10 +271,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var id: AnyJSON
-    public var url: AnyJSON
+    public var id: String
+    public var url: String
 
-    public init(id: AnyJSON, url: AnyJSON) {
+    public init(id: String, url: String) {
         self.id = id
         self.url = url
     }

--- a/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
@@ -208,10 +208,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -220,7 +226,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
@@ -271,10 +271,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-	public var id: AnyJSON
-	public var url: AnyJSON
+	public var id: String
+	public var url: String
 
-	public init(id: AnyJSON, url: AnyJSON) {
+	public init(id: String, url: String) {
 		self.id = id
 		self.url = url
 	}

--- a/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
@@ -208,10 +208,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
 	public var animal: Animal
-	public var breed: String?
+	public var breed: Breed?
 	public var image: Image?
 
-	public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+	public enum Breed: String, Codable, CaseIterable {
+		case large = "Large"
+		case medium = "Medium"
+		case small = "Small"
+	}
+
+	public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
 		self.animal = animal
 		self.breed = breed
 		self.image = image
@@ -220,7 +226,7 @@ public struct Dog: Codable {
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
 		self.animal = try Animal(from: decoder)
-		self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+		self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
 		self.image = try values.decodeIfPresent(Image.self, forKey: "image")
 	}
 

--- a/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
@@ -209,22 +209,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
 	public var animal: Animal
 	public var breed: String?
+	public var image: Image?
 
-	public init(animal: Animal, breed: String? = nil) {
+	public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
 		self.animal = animal
 		self.breed = breed
+		self.image = image
 	}
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
 		self.animal = try Animal(from: decoder)
 		self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+		self.image = try values.decodeIfPresent(Image.self, forKey: "image")
 	}
 
 	public func encode(to encoder: Encoder) throws {
 		var values = encoder.container(keyedBy: StringCodingKey.self)
 		try values.encode(animal, forKey: "animal")
 		try values.encodeIfPresent(breed, forKey: "breed")
+		try values.encodeIfPresent(image, forKey: "image")
 	}
 }
 
@@ -257,6 +261,16 @@ public struct Animal: Codable {
 	public init(className: String, color: String? = nil) {
 		self.className = className
 		self.color = color
+	}
+}
+
+public struct Image: Codable {
+	public var id: AnyJSON
+	public var url: AnyJSON
+
+	public init(id: AnyJSON, url: AnyJSON) {
+		self.id = id
+		self.url = url
 	}
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
@@ -229,10 +229,16 @@ public struct ClassModel: Codable {
 
 public struct Dog: Codable {
     public var animal: Animal
-    public var breed: String?
+    public var breed: Breed?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
+    public enum Breed: String, Codable, CaseIterable {
+        case large = "Large"
+        case medium = "Medium"
+        case small = "Small"
+    }
+
+    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
         self.image = image
@@ -241,7 +247,7 @@ public struct Dog: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
-        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 

--- a/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
@@ -230,22 +230,26 @@ public struct ClassModel: Codable {
 public struct Dog: Codable {
     public var animal: Animal
     public var breed: String?
+    public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil) {
+    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
         self.animal = animal
         self.breed = breed
+        self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
         self.animal = try Animal(from: decoder)
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
+        self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
         try values.encode(animal, forKey: "animal")
         try values.encodeIfPresent(breed, forKey: "breed")
+        try values.encodeIfPresent(image, forKey: "image")
     }
 }
 
@@ -278,6 +282,21 @@ public struct Animal: Codable {
     public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
+    }
+}
+
+public struct Image: Codable {
+    public var identifier: AnyJSON
+    public var url: AnyJSON
+
+    public init(identifier: AnyJSON, url: AnyJSON) {
+        self.identifier = identifier
+        self.url = url
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case url
     }
 }
 

--- a/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
@@ -292,10 +292,10 @@ public struct Animal: Codable {
 }
 
 public struct Image: Codable {
-    public var identifier: AnyJSON
-    public var url: AnyJSON
+    public var identifier: String
+    public var url: String
 
-    public init(identifier: AnyJSON, url: AnyJSON) {
+    public init(identifier: String, url: String) {
         self.identifier = identifier
         self.url = url
     }

--- a/Tests/CreateAPITests/Specs/edgecases.yaml
+++ b/Tests/CreateAPITests/Specs/edgecases.yaml
@@ -1012,10 +1012,11 @@ components:
       required:
         - id
         - url
-      id:
-        type: string
-      url:
-        type: string
+      properties:
+        id:
+          type: string
+        url:
+          type: string
     AnimalFarm:
       type: array
       items:

--- a/Tests/CreateAPITests/Specs/edgecases.yaml
+++ b/Tests/CreateAPITests/Specs/edgecases.yaml
@@ -1009,9 +1009,9 @@ components:
         - id
         - url
       id:
-        - type: string
+        type: string
       url:
-        - type: string
+        type: string
     AnimalFarm:
       type: array
       items:

--- a/Tests/CreateAPITests/Specs/edgecases.yaml
+++ b/Tests/CreateAPITests/Specs/edgecases.yaml
@@ -982,6 +982,8 @@ components:
           properties:
             breed:
               type: string
+            image:
+              $ref: "#/components/schemas/Image"
     Cat:
       allOf:
         - $ref: "#/components/schemas/Animal"
@@ -1001,6 +1003,15 @@ components:
         color:
           type: string
           default: red
+    Image:
+      type: object
+      required:
+        - id
+        - url
+      id:
+        - type: string
+      url:
+        - type: string
     AnimalFarm:
       type: array
       items:

--- a/Tests/CreateAPITests/Specs/edgecases.yaml
+++ b/Tests/CreateAPITests/Specs/edgecases.yaml
@@ -982,6 +982,10 @@ components:
           properties:
             breed:
               type: string
+              enum:
+                - "Large"
+                - "Medium"
+                - "Small"
             image:
               $ref: "#/components/schemas/Image"
     Cat:


### PR DESCRIPTION
## WHAT

When we have this kind OpenAPI schema ↓
```JSON
"Dog": {
  "allOf": [
    {
      "type": "object",
      "additionalProperties": false,
      "required": ["type"],
      "properties": {
        "type": {
          "type": "string",
          "enum": ["dog"]
        }
      }
    },
    {
      "$ref": "#/components/schemas/BaseDog"
    }
  ]
}
```
it fails to decode `type` because currently, CreateAPI generates ↓
``` Swift
public init(from decoder: Decoder) throws {
    self.type = try `Type`(from: decoder) # ← THIS IS WRONG
    self.baseDog = try BaseDog(from: decoder)
}
```

It should be
```Swift
public init(from decoder: Decoder) throws {
    let values = try decoder.container(keyedBy: StringCodingKey.self)
    self.type = try values.decode(`Type`.self, forKey: "type") # ← THIS IS CORRECT
    self.baseDog = try BaseDog(from: decoder)
}
```

In this PR, I've added `isInlineed` to `Property` in order to differentiate `Type` and `BaseDog` generated codes in the example above.

Also, when an object in `allOf` has a reference type property, it fails because currently it is generated as

```yml
# spec
Dog:
    allOf:
      - $ref: "#/components/schemas/Animal"
      - type: object
        properties:
          breed:
            type: string
          image:
            $ref: "#/components/schemas/Image"
```
```Swift
public struct Dog: Codable {
    public var animal: Animal
    public var breed: String?
    public var image: Image?

    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
        self.animal = animal
        self.breed = breed
        self.image = image
    }

    public init(from decoder: Decoder) throws {
        let values = try decoder.container(keyedBy: StringCodingKey.self)
        self.animal = try Animal(from: decoder)
        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
        self.image = try Image(from: decoder) # ← THIS IS WRONG
    }

    public func encode(to encoder: Encoder) throws {
        var values = encoder.container(keyedBy: StringCodingKey.self)
        try values.encode(animal, forKey: "animal")
        try values.encodeIfPresent(breed, forKey: "breed")
        try values.encodeIfPresent(image, forKey: "image")
    }
}
```
but should be
```Swift
public struct Dog: Codable {
    public var animal: Animal
    public var breed: String?
    public var image: Image?

    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
        self.animal = animal
        self.breed = breed
        self.image = image
    }

    public init(from decoder: Decoder) throws {
        let values = try decoder.container(keyedBy: StringCodingKey.self)
        self.animal = try Animal(from: decoder)
        self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
        self.image = try values.decodeIfPresent(Image.self, forKey: "image") # ← THIS IS CORRECT
    }

    public func encode(to encoder: Encoder) throws {
        var values = encoder.container(keyedBy: StringCodingKey.self)
        try values.encode(animal, forKey: "animal")
        try values.encodeIfPresent(breed, forKey: "breed")
        try values.encodeIfPresent(image, forKey: "image")
    }
}
```

## HOW

- [x] Added some tests
- [x] Added `isInlined` to `Property`.