### PR TITLE
Fixed optional decoding from decoder

### DIFF
--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -249,7 +249,7 @@ final class Templates {
     ///
     ///     self.animal = try Animal(from: decoder)
     func decodeFromDecoder(property: Property) -> String {
-        "self.\(property.name.accessor) = try \(property.type)(from: decoder)"
+        "self.\(property.name.accessor) = try\(property.isOptional ? "?" : "") \(property.type)(from: decoder)"
     }
     
     func initFromDecoder(properties: [Property], isUsingCodingKeys: Bool) -> String {


### PR DESCRIPTION
`try Entity(from: decoder)` should be `try? Entity(from: decoder)` if the property is optional?