### PR TITLE
Support multiple discriminator mappings to share one type

### DIFF
--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -246,6 +246,10 @@ struct TypealiasDeclaration: Declaration {
 struct Discriminator {
     let propertyName: String
     let mapping: [String: TypeIdentifier]
+
+    func correspondingMappings(for property: Property) -> Array<(key: String, value: TypeIdentifier)> {
+        mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
+    }
 }
 
 struct DeclarationMetadata {

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -45,10 +45,8 @@ extension Generator {
                 var statements: [String] = []
                 for property in properties {
                     let correspondingMappings = discriminator.mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
-                    if !correspondingMappings.isEmpty {
-                        for mapping in correspondingMappings {
-                            statements.append("case \(mapping.key)(\(property.type))")
-                        }
+                    for mapping in correspondingMappings {
+                        statements.append("case \(mapping.key)(\(property.type))")
                     }
                 }
                 contents.append(statements.joined(separator: "\n"))

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -44,7 +44,7 @@ extension Generator {
             if let discriminator = decl.discriminator {
                 var statements: [String] = []
                 for property in properties {
-                    let correspondingMappings = discriminator.mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
+                    let correspondingMappings = discriminator.correspondingMappings(for: property)
                     for mapping in correspondingMappings {
                         statements.append("case \(mapping.key)(\(property.type))")
                     }

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -41,18 +41,7 @@ extension Generator {
                 contents.append(templates.initializer(properties: properties))
             }
         case .oneOf:
-            if let discriminator = decl.discriminator {
-                var statements: [String] = []
-                for property in properties {
-                    let correspondingMappings = discriminator.correspondingMappings(for: property)
-                    for mapping in correspondingMappings {
-                        statements.append("case \(mapping.key)(\(property.type))")
-                    }
-                }
-                contents.append(statements.joined(separator: "\n"))
-            } else {
-                contents.append(properties.map(templates.case).joined(separator: "\n"))
-            }
+            contents.append(properties.map(templates.case).joined(separator: "\n"))
             contents += decl.nested.map(render)
         }
 
@@ -113,7 +102,7 @@ extension Generator {
                     }
                 }
                 if decl.protocols.isEncodable {
-                    contents.append(templates.encodeOneOf(properties: properties, discriminator: decl.discriminator))
+                    contents.append(templates.encodeOneOf(properties: properties))
                 }
             }
         }

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -351,10 +351,8 @@ final class Templates {
         if let discriminator = discriminator {
             for property in properties {
                 let correspondingMappings = discriminator.mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
-                if !correspondingMappings.isEmpty {
-                    for mapping in correspondingMappings {
-                        statements.append("case .\(mapping.key)(let value): try container.encode(value)")
-                    }
+                for mapping in correspondingMappings {
+                    statements.append("case .\(mapping.key)(let value): try container.encode(value)")
                 }
             }
         } else {

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -311,16 +311,12 @@ final class Templates {
     func initFromDecoderOneOfWithDiscriminator(properties: [Property], discriminator: Discriminator) -> String {
         var statements = ""
         for property in properties {
-            let correspondingMappings = discriminator.mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
-            if !correspondingMappings.isEmpty {
-                for mapping in correspondingMappings {
-                    statements += """
-                    case \"\(mapping.key)\": self = .\(mapping.key)(try container.decode(\(property.type).self))
+            let correspondingMappings = discriminator.correspondingMappings(for: property)
+            for mapping in correspondingMappings {
+                statements += """
+                case \"\(mapping.key)\": self = .\(mapping.key)(try container.decode(\(property.type).self))
 
-                    """
-                }
-            } else {
-                continue
+                """
             }
         }
         
@@ -350,7 +346,7 @@ final class Templates {
         var statements: [String] = []
         if let discriminator = discriminator {
             for property in properties {
-                let correspondingMappings = discriminator.mapping.filter { $1 == property.type }.sorted { $0.key < $1.key }
+                let correspondingMappings = discriminator.correspondingMappings(for: property)
                 for mapping in correspondingMappings {
                     statements.append("case .\(mapping.key)(let value): try container.encode(value)")
                 }

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -314,7 +314,7 @@ final class Templates {
             let correspondingMappings = discriminator.correspondingMappings(for: property)
             for mapping in correspondingMappings {
                 statements += """
-                case \"\(mapping.key)\": self = .\(mapping.key)(try container.decode(\(property.type).self))
+                case \"\(mapping.key)\": self = .\(property.name)(try container.decode(\(property.type).self))
 
                 """
             }
@@ -342,19 +342,9 @@ final class Templates {
         """
     }    
     
-    func encodeOneOf(properties: [Property], discriminator: Discriminator?) -> String {
-        var statements: [String] = []
-        if let discriminator = discriminator {
-            for property in properties {
-                let correspondingMappings = discriminator.correspondingMappings(for: property)
-                for mapping in correspondingMappings {
-                    statements.append("case .\(mapping.key)(let value): try container.encode(value)")
-                }
-            }
-        } else {
-            statements = properties.map {
-                "case .\($0.name)(let value): try container.encode(value)"
-            }
+    func encodeOneOf(properties: [Property]) -> String {
+        let statements: [String] = properties.map {
+            "case .\($0.name)(let value): try container.encode(value)"
         }
 
         return """

--- a/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
@@ -34,6 +34,7 @@ public struct Container: Codable {
 
     public enum Content: Codable {
         case a(A)
+        case d(A)
         case b(B)
         case c(C)
 
@@ -47,6 +48,7 @@ public struct Container: Codable {
 
             switch (try container.decode(Discriminator.self)).kind {
             case "a": self = .a(try container.decode(A.self))
+            case "d": self = .d(try container.decode(A.self))
             case "b": self = .b(try container.decode(B.self))
             case "c": self = .c(try container.decode(C.self))
 
@@ -59,6 +61,7 @@ public struct Container: Codable {
             var container = encoder.singleValueContainer()
             switch self {
             case .a(let value): try container.encode(value)
+            case .d(let value): try container.encode(value)
             case .b(let value): try container.encode(value)
             case .c(let value): try container.encode(value)
             }

--- a/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
@@ -34,7 +34,6 @@ public struct Container: Codable {
 
     public enum Content: Codable {
         case a(A)
-        case d(A)
         case b(B)
         case c(C)
 
@@ -48,7 +47,7 @@ public struct Container: Codable {
 
             switch (try container.decode(Discriminator.self)).kind {
             case "a": self = .a(try container.decode(A.self))
-            case "d": self = .d(try container.decode(A.self))
+            case "d": self = .a(try container.decode(A.self))
             case "b": self = .b(try container.decode(B.self))
             case "c": self = .c(try container.decode(C.self))
 
@@ -61,7 +60,6 @@ public struct Container: Codable {
             var container = encoder.singleValueContainer()
             switch self {
             case .a(let value): try container.encode(value)
-            case .d(let value): try container.encode(value)
             case .b(let value): try container.encode(value)
             case .c(let value): try container.encode(value)
             }

--- a/Tests/CreateAPITests/Specs/discriminator.yaml
+++ b/Tests/CreateAPITests/Specs/discriminator.yaml
@@ -53,3 +53,4 @@ components:
               a: "#/components/schemas/A"
               b: "#/components/schemas/B"
               c: "#/components/schemas/C"
+              d: "#/components/schemas/A"


### PR DESCRIPTION
## Background

Currently, CreateAPI only supports a unique type for each mapping case.
For example, if we have

```yml
Container:
      type: object
      required:
        - content
      properties:
        content:
          oneOf:
            - $ref: "#/components/schemas/A"
            - $ref: "#/components/schemas/B"
            - $ref: "#/components/schemas/C"
          discriminator:
            propertyName: kind
            mapping:
              a: "#/components/schemas/A"
              b: "#/components/schemas/B"
              c: "#/components/schemas/C"
              d: "#/components/schemas/A"
```

it only generates `.a` but `.d` is not generated.
This is because we only use the first case with the property type.

https://github.com/CreateAPI/CreateAPI/blob/a59c76632f3199ddb016447dc04ceb83102d3f61/Sources/CreateAPI/Generator/Templates.swift#L314

## How

In this PR, I have fixed the issue above by checking the `mapping` keys and updated the discriminator test case for the case when two enum cases share one type.

Hope the changes make sense. Let me know if you have better options 🙇🏽 