### PR TITLE
Update GitHub Workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Tests
         run: swift test
   macos-compile-generated-code:
@@ -24,6 +24,6 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Compile Generated Code
         run: ./Scripts/test-generated.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,24 +6,27 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - main
 
 jobs:
-  macos-run-tests:
-    name: Unit Tests (macOS, Xcode 13.2)
-    runs-on: macOS-11
+  macos:
+    name: macOS (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: ["13.4", "13.2.1"]
+        include:
+          - xcode: "13.4"
+            macos: macOS-12
+          - xcode: "13.2.1"
+            macos: macOS-11
+    runs-on: ${{ matrix.macos }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Repo
+        uses: actions/checkout@v3
       - name: Run Tests
         run: swift test
-  macos-compile-generated-code:
-    name: Compile Generated Code
-    runs-on: macOS-11
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
-    steps:
-      - uses: actions/checkout@v3
       - name: Compile Generated Code
         run: ./Scripts/test-generated.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: "Create API CI"
 
-on: 
+on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
-    branches: 
+    branches:
       - '*'
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: Run Tests
         run: swift test
   macos-compile-generated-code:
-    name: Unit Tests (macOS, Xcode 13.2)
+    name: Compile Generated Code
     runs-on: macOS-11
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/Scripts/test-generated.sh
+++ b/Scripts/test-generated.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 
 cd ./Tests
 xcodebuild clean
-xcodebuild build -scheme 'GeneratedPackages' -destination "OS=15.2,name=iPhone 13"
+xcodebuild build -scheme 'GeneratedPackages' -destination "generic/platform=iOS Simulator"


### PR DESCRIPTION
Prior to this change, the CI checks ran using only a single version of Xcode (and Swift). 

This change updates the workflow to use a matrix of different Xcode versions meaning that we get coverage with both the Swift 5.5 and 5.6 compiler. 