### PR TITLE
Revert "Fix `String` type with `byte` format"

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -242,8 +242,6 @@ extension Generator {
             return .builtin("URL")
         case .other(let other) where other == "uuid":
             return .builtin("UUID")
-        case .byte:
-          return .builtin("Data")
         default: break
         }
         return .builtin("String")


### PR DESCRIPTION
Reverts #25
Closes #29

> According to the Swagger documentation, they are defined as Base64-encoded characters.
> So it would be correct to treat it as a `String`, wouldn't it?
> 
> 
> https://swagger.io/docs/specification/data-models/data-types/#format
> > An optional format modifier serves as a hint at the contents and format of the string. OpenAPI defines the following built-in string formats:
> ...
> byte – base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==

cc @simorgh3196, @mattia