### PR TITLE
Fix comment generation when using other kind of linebreaks

### DIFF
--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -697,17 +697,8 @@ extension String {
 }
 
 extension String {
-    // Unlike `components(separatedBy: "\n")`, it keeps empty lines.
     var lines: [String] {
-        var lines: [String] = []
-        var index = startIndex
-        let input = self.trimmingCharacters(in: .whitespacesAndNewlines)
-        while let newLineIndex = input[index...].firstIndex(of: "\n") {
-            lines.append(String(input[index..<newLineIndex]))
-            index = input.index(after: newLineIndex)
-        }
-        lines.append(String(input[index...]))
-        return lines
+        self.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .newlines)
     }
 }
 

--- a/Tests/CreateAPITests/Expected/cookpad/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/cookpad/Sources/Entities.swift
@@ -13,10 +13,12 @@ public struct Collection: Codable {
     /// Example: "BBQ Classics"
     public var title: String
     /// A longer description of the collection.
+    /// This is also a comment, but on a new line using the \n line break.
     ///
     /// Example: "The sun is shining? The BBQ is out? Check out this collection of recipes for the perfect summer BBQ."
     public var description: String
     /// The number of recipes in this collection.
+    /// This is also a comment, but on a new line using the \r line break.
     ///
     /// Example: 27
     public var recipeCount: Int

--- a/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
@@ -14,6 +14,8 @@ public struct A: Codable {
 }
 
 public struct B: Codable {
+    /// This is a description
+    /// And it should be on multiple lines
     public var kind: String
 
     public init(kind: String) {

--- a/Tests/CreateAPITests/Specs/cookpad.json
+++ b/Tests/CreateAPITests/Specs/cookpad.json
@@ -202,13 +202,13 @@
           },
           "description": {
             "type": "string",
-            "description": "A longer description of the collection.",
+            "description": "A longer description of the collection.\nThis is also a comment, but on a new line using the \\n line break.",
             "nullable": false,
             "example": "The sun is shining? The BBQ is out? Check out this collection of recipes for the perfect summer BBQ."
           },
           "recipe_count": {
             "type": "integer",
-            "description": "The number of recipes in this collection.",
+            "description": "The number of recipes in this collection.\rThis is also a comment, but on a new line using the \\r line break.",
             "nullable": false,
             "example": 27
           },

--- a/Tests/CreateAPITests/Specs/discriminator.yaml
+++ b/Tests/CreateAPITests/Specs/discriminator.yaml
@@ -29,6 +29,9 @@ components:
       properties:
         kind:
           type: string
+          description: |
+            This is a description
+            And it should be on multiple lines
     C:
       type: object
       required:


### PR DESCRIPTION
# Background

- Closes #44

It was reported that when a string that is used in comments uses `\r` for line breaks, the generated code will incorrectly fail to prefix the line with `///` resulting in non-compiling source files.

# Fix

From what I could tell, the easiest way to fix this is to separate into components based on anything within the predefined `.newlines` `CharacterSet`. 

It was a bit tricky to do this using `firstIndex(of:)` in the existing while loop, whereas it was much easier to use `components(separatedBy:)`. However, I am wary because of this comment:


```swift
// Unlike `components(separatedBy: "\n")`, it keeps empty lines.
```

However when I compared the implementation, I didn't see a difference in output:

<img width="1624" alt="Screenshot 2022-06-29 at 10 21 50" src="https://user-images.githubusercontent.com/482871/176405488-cf74e3ed-c0a3-47e4-a66d-0377b9a8f84c.png">

@kean, please could you confirm if I missed anything here? It looks like it works as expected using the updated approach but I might have misunderstood 🙏 