### PR TITLE
Remove main.swift and mark CreateAPI as @main type directly

### DIFF
--- a/Sources/CreateAPI/CreateAPI.swift
+++ b/Sources/CreateAPI/CreateAPI.swift
@@ -3,17 +3,12 @@
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
 import ArgumentParser
-import OpenAPIKit30
-import Foundation
-import Yams
 
+@main
 struct CreateAPI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "create-api",
         abstract: "A Swift command-line tool to auto-generate code for OpenAPI specs",
-        subcommands: [Generate.self])
-
-    init() { }
+        subcommands: [Generate.self]
+    )
 }
-
-CreateAPI.main()


### PR DESCRIPTION
> [SE-0281](https://github.com/apple/swift-evolution/blob/master/proposals/0281-main-attribute.md) introduced a new `@main` attribute to allow us to declare where the entry point for a program is. This allows us to control exactly which part of our code should start running, which is particularly useful for command-line programs.

https://www.hackingwithswift.com/swift/5.3/atmain

It's only a small improvement, but since CreateAPI supports Swift 5.5 and above, we might as well take advantage of it