### PR TITLE
Update generator code to point to https://github.com/kean/Get and not CreateAPI/Get

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ paths:
   isGeneratingResponseHeaders: true
   # Add operation id to each request
   isAddingOperationIds: false
-  # The types to import, by default uses "Get" (https://github.com/CreateAPI/Get)
+  # The types to import, by default uses "Get" (https://github.com/kean/Get)
   imports: ["Get"]
   # Example, "- empty: Void"
   overrideResponses: {}

--- a/Sources/CreateAPI/Generator/Generator+Package.swift
+++ b/Sources/CreateAPI/Generator/Generator+Package.swift
@@ -7,7 +7,7 @@ import Foundation
 extension Generator {
     func makePackageFile(name: String) -> String {
         let packages: String = [
-            #".package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")"#,
+            #".package(url: "https://github.com/kean/Get", from: "0.3.1")"#,
             isHTTPHeadersDependencyNeeded ? #".package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0")"# : nil,
             isNaiveDateNeeded ? #".package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0")"# : nil,
             isQueryEncoderNeeded ? #".package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")"# : nil,

--- a/Tests/CreateAPITests/Expected/OctoKit/Package.swift
+++ b/Tests/CreateAPITests/Expected/OctoKit/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "OctoKit", targets: ["OctoKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/cookpad/Package.swift
+++ b/Tests/CreateAPITests/Expected/cookpad/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "cookpad", targets: ["cookpad"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "cookpad", dependencies: [

--- a/Tests/CreateAPITests/Expected/discriminator/Package.swift
+++ b/Tests/CreateAPITests/Expected/discriminator/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "discriminator", targets: ["discriminator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "discriminator", dependencies: [

--- a/Tests/CreateAPITests/Expected/edgecases-change-access-control/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-change-access-control/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-change-access-control", targets: ["edgecases-change-access-control"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-coding-keys/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-coding-keys/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-coding-keys", targets: ["edgecases-coding-keys"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-default/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-default/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-default", targets: ["edgecases-default"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-disable-acronyms", targets: ["edgecases-disable-acronyms"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-disable-enums/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-enums/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-disable-enums", targets: ["edgecases-disable-enums"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-indent-with-two-width-spaces", targets: ["edgecases-indent-with-two-width-spaces"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-int32-int64/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-int32-int64/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-int32-int64", targets: ["edgecases-int32-int64"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-rename-properties/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename-properties/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-rename-properties", targets: ["edgecases-rename-properties"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-rename/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-rename", targets: ["edgecases-rename"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-tabs/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-tabs/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-tabs", targets: ["edgecases-tabs"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/edgecases-yaml-config/Package.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-yaml-config/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "edgecases-yaml-config", targets: ["edgecases-yaml-config"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/NaiveDate", from: "1.0.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")

--- a/Tests/CreateAPITests/Expected/inlining-default/Package.swift
+++ b/Tests/CreateAPITests/Expected/inlining-default/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "inlining-default", targets: ["inlining-default"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "inlining-default", dependencies: [

--- a/Tests/CreateAPITests/Expected/petstore-base-class/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-base-class/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-base-class", targets: ["petstore-base-class"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-change-entityname/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-change-entityname/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-change-entityname", targets: ["petstore-change-entityname"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-change-filename/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-change-filename/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-change-filename", targets: ["petstore-change-filename"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-change-namespace-when-operations-style/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-change-namespace-when-operations-style/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-change-namespace-when-operations-style", targets: ["petstore-change-namespace-when-operations-style"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-change-namespace-when-rest-style/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-change-namespace-when-rest-style/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-change-namespace-when-rest-style", targets: ["petstore-change-namespace-when-rest-style"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-custom-imports/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-custom-imports/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-custom-imports", targets: ["petstore-custom-imports"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-default/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-default/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-default", targets: ["petstore-default"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-disable-comments/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-disable-comments/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-disable-comments", targets: ["petstore-disable-comments"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-disable-init-with-coder/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-disable-init-with-coder/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-disable-init-with-coder", targets: ["petstore-disable-init-with-coder"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-disable-inlining/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-disable-inlining/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-disable-inlining", targets: ["petstore-disable-inlining"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-disable-mutable-properties/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-disable-mutable-properties/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-disable-mutable-properties", targets: ["petstore-disable-mutable-properties"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "petstore-disable-mutable-properties", dependencies: [

--- a/Tests/CreateAPITests/Expected/petstore-enable-mutable-properties/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-enable-mutable-properties/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-enable-mutable-properties", targets: ["petstore-enable-mutable-properties"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "petstore-enable-mutable-properties", dependencies: [

--- a/Tests/CreateAPITests/Expected/petstore-generate-classes/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-generate-classes/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-generate-classes", targets: ["petstore-generate-classes"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-only-schemas/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-only-schemas/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-only-schemas", targets: ["petstore-only-schemas"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "petstore-only-schemas", dependencies: [

--- a/Tests/CreateAPITests/Expected/petstore-operation-id/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-operation-id/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-operation-id", targets: ["petstore-operation-id"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-single-threaded/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-single-threaded/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-single-threaded", targets: ["petstore-single-threaded"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-some-entities-as-classes/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-some-entities-as-classes/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-some-entities-as-classes", targets: ["petstore-some-entities-as-classes"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-some-entities-as-structs/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-some-entities-as-structs/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-some-entities-as-structs", targets: ["petstore-some-entities-as-structs"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/petstore-split/Package.swift
+++ b/Tests/CreateAPITests/Expected/petstore-split/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "petstore-split", targets: ["petstore-split"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/HTTPHeaders", from: "0.1.0"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],

--- a/Tests/CreateAPITests/Expected/strip-parent-name-nested-objects-default/Package.swift
+++ b/Tests/CreateAPITests/Expected/strip-parent-name-nested-objects-default/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "strip-parent-name-nested-objects-default", targets: ["strip-parent-name-nested-objects-default"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "strip-parent-name-nested-objects-default", dependencies: [

--- a/Tests/CreateAPITests/Expected/strip-parent-name-nested-objects-enabled/Package.swift
+++ b/Tests/CreateAPITests/Expected/strip-parent-name-nested-objects-enabled/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "strip-parent-name-nested-objects-enabled", targets: ["strip-parent-name-nested-objects-enabled"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1")
+        .package(url: "https://github.com/kean/Get", from: "0.3.1")
     ],
     targets: [
         .target(name: "strip-parent-name-nested-objects-enabled", dependencies: [

--- a/Tests/CreateAPITests/Expected/test-query-parameters/Package.swift
+++ b/Tests/CreateAPITests/Expected/test-query-parameters/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "test-query-parameters", targets: ["test-query-parameters"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CreateAPI/Get", from: "0.3.1"), 
+        .package(url: "https://github.com/kean/Get", from: "0.3.1"), 
         .package(url: "https://github.com/CreateAPI/URLQueryEncoder", from: "0.2.0")
     ],
     targets: [

--- a/Tests/GeneratedPackages.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/GeneratedPackages.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Get",
-        "repositoryURL": "https://github.com/CreateAPI/Get",
+        "repositoryURL": "https://github.com/kean/Get",
         "state": {
           "branch": null,
           "revision": "be3879cb580c141b6d4cbb80fba18c7b5028c552",


### PR DESCRIPTION
# Background 

- #35 

While Get did briefly move to the CreateAPI organisation, it moved back to Alex's personal account since he remains the primary owner

```bash
$ curl -I https://github.com/CreateAPI/Get
HTTP/2 301 
server: GitHub.com
date: Sat, 02 Jul 2022 13:13:30 GMT
location: https://github.com/kean/Get
```

Projects should use the proper URL and not rely on the redirect since this can cause ambiguity that will eventually become an error in future versions of SPM (https://github.com/CreateAPI/CreateAPI/issues/40#issuecomment-1172760304)

# Changes 

In this change, I update the generator code (and the expectations) to use the correct URL