### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
-export EXECUTABLE_NAME = CreateAPI
-PREFIX = /usr/local
-INSTALL_PATH = $(PREFIX)/bin/create-api
-CURRENT_PATH = $(PWD)
-REPO = https://github.com/CreateAPI/$(EXECUTABLE_NAME)
-SWIFT_BUILD_FLAGS = --disable-sandbox -c release # --arch arm64 # --arch x86_64
-EXECUTABLE_PATH = $(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/$(EXECUTABLE_NAME)
+SWIFT_BUILD_FLAGS = --disable-sandbox -c release
+BINARIES_PATH = /usr/local/bin
+EXECUTABLE_PATH = $(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/create-api
+
+.PHONY: build install uninstall
 
 build:
 	swift build $(SWIFT_BUILD_FLAGS)
 
 install: build
-	mkdir -p $(PREFIX)/bin
-	sudo cp -f $(EXECUTABLE_PATH) $(INSTALL_PATH)
+	sudo install -d "$(BINARIES_PATH)"
+	sudo install "$(EXECUTABLE_PATH)" "$(BINARIES_PATH)"
+
+uninstall:
+	sudo rm -f "$(BINARIES_PATH)/create-api"


### PR DESCRIPTION
# Related

Closes #53 

# Why

The `make install` command wasn't working since it was a little outdated. 

# Changes

In this change, I updated the **Makefile** to fix the `install` command and while doing so, I added a few extra tweaks:

- Use 'install' command line tool
- Mark steps as PHONY
- Add uninstall step
- Remove unused constants