### PR TITLE
Tests - Automatic Path Finding and Remove Environment Variables

### DIFF
--- a/Tests/CreateAPITests/Snapshots.swift
+++ b/Tests/CreateAPITests/Snapshots.swift
@@ -26,7 +26,7 @@ func compare(expected: String, actual: String, file: StaticString = #file, line:
     }
 }
 
-fileprivate func diff(expectedURL: URL, actualURL: URL, file: StaticString = #file) throws {
+private func diff(expectedURL: URL, actualURL: URL, file: StaticString = #file) throws {
     func contents(at url: URL) throws -> [URL] {
         try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
     }
@@ -50,7 +50,7 @@ fileprivate func diff(expectedURL: URL, actualURL: URL, file: StaticString = #fi
 }
 
 @discardableResult
-fileprivate func shell(_ args: String...) -> Int32 {
+private func shell(_ args: String...) -> Int32 {
     let task = Process()
     task.launchPath = "/usr/bin/env"
     task.arguments = args

--- a/Tests/CreateAPITests/Snapshots.swift
+++ b/Tests/CreateAPITests/Snapshots.swift
@@ -5,8 +5,8 @@
 import Foundation
 import XCTest
 
-fileprivate let generateSnapshots = false
-fileprivate let openDiff = false
+private let generateSnapshots = false
+private let openDiff = false
 
 func compare(expected: String, actual: String, file: StaticString = #file, line: UInt = #line) throws {
     let expectedURL = Bundle.module.resourceURL!

--- a/Tests/CreateAPITests/Snapshots.swift
+++ b/Tests/CreateAPITests/Snapshots.swift
@@ -5,18 +5,19 @@
 import Foundation
 import XCTest
 
-// TODO: Find it automatically
-var projectPath = ("~/Developer/CreateAPI/" as NSString).expandingTildeInPath
-
 func compare(expected: String, actual: String, file: StaticString = #file, line: UInt = #line) throws {
     let env = ProcessInfo.processInfo.environment
     let expectedURL = Bundle.module.resourceURL!
         .appendingPathComponent("Expected")
         .appendingPathComponent(expected)
     let actualURL = URL(fileURLWithPath: actual)
+    
     if env["GENERATE_SNAPSHOTS"] == "true" || !FileManager.default.fileExists(atPath: expectedURL.path) {
-        let projectPath = (projectPath as NSString).expandingTildeInPath
-        let destinationURL = URL(fileURLWithPath: projectPath + "/Tests/CreateAPITests/Expected/\(actualURL.lastPathComponent)")
+        let testsFolderPath = #filePath
+            .split(separator: "/")
+            .dropLast()
+            .joined(separator: "/")
+        let destinationURL = URL(fileURLWithPath: "/" + testsFolderPath + "/Expected/\(actualURL.lastPathComponent)")
         try? FileManager.default.removeItem(at: destinationURL)
         try FileManager.default.copyItem(at: actualURL, to: destinationURL)
     } else {
@@ -24,7 +25,7 @@ func compare(expected: String, actual: String, file: StaticString = #file, line:
     }
 }
 
-private func diff(expectedURL: URL, actualURL: URL, file: StaticString = #file, line: UInt = #line) throws {
+fileprivate func diff(expectedURL: URL, actualURL: URL, file: StaticString = #file, line: UInt = #line) throws {
     func contents(at url: URL) throws -> [URL] {
         try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
     }
@@ -48,7 +49,7 @@ private func diff(expectedURL: URL, actualURL: URL, file: StaticString = #file, 
 }
 
 @discardableResult
-func shell(_ args: String...) -> Int32 {
+fileprivate func shell(_ args: String...) -> Int32 {
     let task = Process()
     task.launchPath = "/usr/bin/env"
     task.arguments = args


### PR DESCRIPTION
`#filePath` is the closest we can get in regards to "automatic file path finding".