### PR TITLE
Produce an artifactbundle when making releases 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["13.4", "13.2.1"]
+        xcode: ["13.4.1", "13.2.1"]
         include:
-          - xcode: "13.4"
+          - xcode: "13.4.1"
             macos: macOS-12
           - xcode: "13.2.1"
             macos: macOS-11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: "Release CreateAPI"
+
+on:
+  release:
+    types:
+    - created
+
+jobs:
+  release:
+    name: Upload Artifact Bundle
+    runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+    steps:
+    # Clone the Repo
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+
+    # Build the create-api.artifactbundle
+    - name: Build Artifact Bundle
+      run: make artifactbundle "version={{ github.event.release.tag_name }}"
+
+    # Upload it to the release
+    - name: Upload Artifact Bundle
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./create-api.artifactbundle.zip
+        asset_name: create-api.artifactbundle.zip
+        asset_content_type: application/zip

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-SWIFT_BUILD_FLAGS = --disable-sandbox -c release
+SWIFT_BUILD_FLAGS = --disable-sandbox -c release --arch x86_64 --arch arm64
 BINARIES_PATH = /usr/local/bin
 EXECUTABLE_PATH = $(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/create-api
 
-.PHONY: build install uninstall documentation
+.PHONY: build install uninstall documentation artifactbundle
 
 build:
 	swift build $(SWIFT_BUILD_FLAGS)
@@ -13,6 +13,9 @@ install: build
 
 uninstall:
 	sudo rm -f "$(BINARIES_PATH)/create-api"
+
+artifactbundle: build
+	scripts/artifactbundle.sh "$(version)" "$(EXECUTABLE_PATH)"
 
 documentation:
 	sourcery

--- a/Scripts/artifactbundle.sh
+++ b/Scripts/artifactbundle.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eo pipefail
+
+# NOTE: Assuming macOS. Linux is not supported yet.
+# $1 == Version
+# $2 == Path to binary
+
+version="$1"
+if [[ -z "$version" ]]
+then
+  echo "You must specify a version" 1>&2
+  exit 1
+fi
+
+input_binary="$2"
+if [[ ! -f "$input_binary" ]]
+then
+  echo "You must specify an input binary path" 1>&2
+  exit 1
+fi
+
+# Reset the artifactbundle directory
+bundle_name=create-api.artifactbundle
+rm -rf "$bundle_name"
+
+# Move the binary into the appropriate location
+binary_path="$bundle_name/create-api-macos/bin/create-api"
+mkdir -p "$(dirname "$binary_path")"
+cp "$input_binary" "$binary_path"
+echo "Copied binary to $binary_path"
+
+# Write the info.json manifest
+info_path="$bundle_name/info.json"
+cat > "$info_path" <<-_EOT_
+{
+  "schemaVersion": "1.0",
+  "artifacts": {
+    "create-api": {
+      "type": "executable",
+      "version": "$version",
+      "variants": [
+        {
+          "path": "create-api-macos/bin/create-api",
+          "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+        }
+      ]
+    }
+  }
+}
+_EOT_
+echo "Written manifest to $info_path"
+
+# Compress the bundle and cleanup
+echo "Compressing..."
+rm -f "$bundle_name.zip"
+zip -r "$bundle_name.zip" "$bundle_name"
+rm -rf "$bundle_name"
+echo "Done"

--- a/Scripts/artifactbundle.sh
+++ b/Scripts/artifactbundle.sh
@@ -56,4 +56,7 @@ echo "Compressing..."
 rm -f "$bundle_name.zip"
 zip -r "$bundle_name.zip" "$bundle_name"
 rm -rf "$bundle_name"
-echo "Done"
+
+# Print the SHA
+checksum=$(shasum -a 256 "$bundle_name.zip" | awk '{ print $1 }')
+echo "Done ($checksum)"


### PR DESCRIPTION
# Related Links

- #48 

# Background 

When creating and using Swift Package plugins, there are a couple of ways that you can approach it:

1. The vendor (or even the consumer) can use the executable's package as a dependency
2. The consume can add their own `.binaryTarget` dependency 

The second option is great when you don't want to have to concern yourself with potentially complex build pipelines for the build tools given that usually we work with precompiled binaries.

To do this, the vendor needs to provide an artifactbundle as described in [SE-[0305](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md)](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md).

# Changes

In this Pull Request, I do a few things to introduce the bundle:

1. Update `make build` so that it produces a universal binary that works on Intel or Apple Silicon Macs
2. Add a new **artifactbundle.sh** script that takes a version number and binary path and zips the correctly structured bundle 
3. Add a new `make artifactbundle version={VERSION}` step
4. Add a new release workflow that automatically builds and uploads the artifactbundle on every release 
5. Switch to Xcode 13.4.1 (bump up from 13.4) on CI

There is still one last manual step, which is to look for the .zip file SHA in the build log and add it to the release notes, but since writing the release notes remains manual still (I like GitHub's generated contents), I will keep this manual for the time being. 

---

For reference, this enables users of CreateAPI start writing Package.swift files like this:

**Package.swift**

```swift
// swift-tools-version: 5.6
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "MyAPIKit",
    products: [
        .library(
            name: "MyAPIKit",
            targets: ["MyAPIKit"]
        )
    ],
    targets: [
        .target(
            name: "MyAPIKit",
            dependencies: [
                .target(name: "CreateAPI")
            ]
        ),
        .binaryTarget(
            name: "create-api",
            url: "https://github.com/liamnichols/CreateAPI/releases/download/0.0.7/create-api.artifactbundle.zip",
            checksum: "9d06c3c737c1a11b073984a4f250a8de0347a3b1d5403b095529f3d93b433e63"
        ),
        .plugin(
            name: "CreateAPI",
            capability: .buildTool(),
            dependencies: [
                .target(name: "create-api")
            ]
        )
    ]
)
```

And then adding their own plugin like so 

**Plugins/CreateAPI/Plugin.swift**

```swift
import Foundation
import PackagePlugin

@main
struct Plugin: BuildToolPlugin {
    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
        let schema = context.package.directory.appending("schema.yml")
        let config = context.package.directory.appending("create-api.yml")

        return [
            .buildCommand(
                displayName: "Generating OpenAPI",
                executable: try context.tool(named: "create-api").path,
                arguments: [
                    "generate",
                    "--module", target.name,
                    "--config", config,
                    "--output", context.pluginWorkDirectory,
                    schema
                ],
                inputFiles: [
                    schema,
                    config
                ],
                outputFiles: [
                    context.pluginWorkDirectory.appending("Paths.swift"),
                    context.pluginWorkDirectory.appending("Entities.swift")
                ]
            )
        ]
    }
}
```

Before documenting this, I want to try it out for myself a bit and work out where we need to improve things and what works best since there are a few different approaches that can be used when writing plugins. After merging this and getting a release out though, I'll certainly share some instructions back in the linked ticket. 