### PR TITLE
Add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Alexander Grebenyuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/CreateAPI/CreateAPI.swift
+++ b/Sources/CreateAPI/CreateAPI.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import ArgumentParser
 
 @main

--- a/Sources/CreateAPI/Generate.swift
+++ b/Sources/CreateAPI/Generate.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import ArgumentParser
 import CreateOptions
 import OpenAPIKit30

--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 import OpenAPIKit30
 

--- a/Sources/CreateAPI/Generator/Generator+Package.swift
+++ b/Sources/CreateAPI/Generator/Generator+Package.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 
 extension Generator {

--- a/Sources/CreateAPI/Generator/Generator+Paths.swift
+++ b/Sources/CreateAPI/Generator/Generator+Paths.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import CreateOptions
 import OpenAPIKit30
 import Foundation

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import OpenAPIKit30
 import Foundation
 

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import OpenAPIKit30
 import Foundation
 import GrammaticalNumber

--- a/Sources/CreateAPI/Generator/Generator.swift
+++ b/Sources/CreateAPI/Generator/Generator.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import CreateOptions
 import OpenAPIKit30
 import Foundation

--- a/Sources/CreateAPI/Generator/Naming.swift
+++ b/Sources/CreateAPI/Generator/Naming.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import CreateOptions
 import Foundation
 

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import CreateOptions
 import OpenAPIKit30
 import Foundation

--- a/Sources/CreateAPI/Helpers/Files.swift
+++ b/Sources/CreateAPI/Helpers/Files.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 
 extension String {

--- a/Sources/CreateAPI/Helpers/Helpers.swift
+++ b/Sources/CreateAPI/Helpers/Helpers.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import CreateOptions
 import Foundation
 import OpenAPIKit30

--- a/Sources/CreateAPI/Helpers/OpenAPI+Extensions.swift
+++ b/Sources/CreateAPI/Helpers/OpenAPI+Extensions.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 import OpenAPIKit30
 

--- a/Sources/CreateAPI/Helpers/ParallelDocumentParser.swift
+++ b/Sources/CreateAPI/Helpers/ParallelDocumentParser.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 import OpenAPIKit30
 

--- a/Sources/CreateAPI/Helpers/Watcher.swift
+++ b/Sources/CreateAPI/Helpers/Watcher.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 #if canImport(FileWatcher)
 import Foundation
 import FileWatcher

--- a/Tests/CreateAPITests/GenerateBaseTests.swift
+++ b/Tests/CreateAPITests/GenerateBaseTests.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import XCTest
 import OpenAPIKit30
 @testable import create_api

--- a/Tests/CreateAPITests/GenerateFeaturesTests.swift
+++ b/Tests/CreateAPITests/GenerateFeaturesTests.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import XCTest
 import OpenAPIKit30
 @testable import create_api

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import XCTest
 import OpenAPIKit30
 @testable import create_api

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import XCTest
 import OpenAPIKit30
 @testable import create_api

--- a/Tests/CreateAPITests/Helpers.swift
+++ b/Tests/CreateAPITests/Helpers.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 import XCTest
 import OpenAPIKit30

--- a/Tests/CreateAPITests/HelpersTests.swift
+++ b/Tests/CreateAPITests/HelpersTests.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 @testable import CreateOptions
 import XCTest
 import class Foundation.Bundle

--- a/Tests/CreateAPITests/Snapshots.swift
+++ b/Tests/CreateAPITests/Snapshots.swift
@@ -1,7 +1,3 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
-
 import Foundation
 import XCTest
 


### PR DESCRIPTION
- #69 

To publish to Homebrew, all projects must have a license and I noticed that most repos in the CreateAPI org were missing one. I'm following what HTTPHeaders uses and going with MIT. 

If you are ok with this @kean, I'll go ahead and just push the file directly to the other repos rather than creating Pull Requests for each one. 