### PR TITLE
Rename `overridenResponses` to `overriddenResponses` and `overridenBodyTypes` to `overriddenBodyTypes`

### DIFF
--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -92,8 +92,8 @@ Below you can find the complete documentation for all available options.
   - [isGeneratingResponseHeaders](#pathsisgeneratingresponseheaders)
   - [isAddingOperationIds](#pathsisaddingoperationids)
   - [imports](#pathsimports)
-  - [overridenResponses](#pathsoverridenresponses)
-  - [overridenBodyTypes](#pathsoverridenbodytypes)
+  - [overriddenResponses](#pathsoverriddenresponses)
+  - [overriddenBodyTypes](#pathsoverriddenbodytypes)
   - [isInliningSimpleRequests](#pathsisinliningsimplerequests)
   - [isInliningSimpleQueryParameters](#pathsisinliningsimplequeryparameters)
   - [simpleQueryParametersThreshold](#pathssimplequeryparametersthreshold)
@@ -509,7 +509,7 @@ Adds the operation id to each request
 Modules to be imported within the source files for generated requests
 
 
-### paths.overridenResponses
+### paths.overriddenResponses
 
 **Type:** [String: String]<br />
 **Default:** `[:]`
@@ -520,12 +520,12 @@ For example:
 
 ```yaml
 paths:
-  overridenResponses:
+  overriddenResponses:
     MyApiResponseType: MyCustomDecodableType
 ```
 
 
-### paths.overridenBodyTypes
+### paths.overriddenBodyTypes
 
 **Type:** [String: String]<br />
 **Default:** `[:]`
@@ -536,7 +536,7 @@ For example:
 
 ```yaml
 paths:
-  overridenBodyTypes:
+  overriddenBodyTypes:
     application/octocat-stream: String
 ```
 

--- a/Sources/CreateAPI/Generator/Generator+Paths.swift
+++ b/Sources/CreateAPI/Generator/Generator+Paths.swift
@@ -652,7 +652,7 @@ extension Generator {
                 guard let name = reference.name else {
                     throw GeneratorError("Response reference name is missing")
                 }
-                if let rename = options.paths.overridenResponses[name] {
+                if let rename = options.paths.overriddenResponses[name] {
                     return BodyType(type: TypeName(rename))
                 }
                 guard let key = OpenAPI.ComponentKey(rawValue: name), let value = spec.components.responses[key] else {
@@ -692,9 +692,9 @@ extension Generator {
             return BodyType("Void")
         }
         
-        if !options.paths.overridenBodyTypes.isEmpty {
+        if !options.paths.overriddenBodyTypes.isEmpty {
             for key in content.keys {
-                if let type = options.paths.overridenBodyTypes[key.rawValue] {
+                if let type = options.paths.overriddenBodyTypes[key.rawValue] {
                     return BodyType(type)
                 }
             }
@@ -759,7 +759,7 @@ extension Generator {
         if firstContent(for: [.other("application/json-patch+json")]) != nil {
             return BodyType("Data") // Currently isn't supported
         }
-        try handle(warning: "Unknown body content types: \(content.keys), defaulting to Data. Use paths.overridenBodyTypes to add support for your content types.")
+        try handle(warning: "Unknown body content types: \(content.keys), defaulting to Data. Use paths.overriddenBodyTypes to add support for your content types.")
         return BodyType("Data")
     }
         

--- a/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
+++ b/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
@@ -327,7 +327,9 @@ extension ConfigOptions.Paths: Decodable {
         case isGeneratingResponseHeaders
         case isAddingOperationIds
         case imports
+        case overriddenResponses
         case overridenResponses
+        case overriddenBodyTypes
         case overridenBodyTypes
         case isInliningSimpleRequests
         case isInliningSimpleQueryParameters
@@ -366,8 +368,18 @@ extension ConfigOptions.Paths: Decodable {
             defaultValue: ["Get"]
         )
 
+        overriddenResponses = try container.decode([String: String].self,
+            forKey: .overriddenResponses,
+            defaultValue: [:]
+        )
+
         overridenResponses = try container.decode([String: String].self,
             forKey: .overridenResponses,
+            defaultValue: [:]
+        )
+
+        overriddenBodyTypes = try container.decode([String: String].self,
+            forKey: .overriddenBodyTypes,
             defaultValue: [:]
         )
 
@@ -412,6 +424,8 @@ extension ConfigOptions.Paths: Decodable {
         )
 
         container.recordPotentialIssues(deprecations: [
+            (.overridenResponses, "Renamed to 'overriddenResponses'."),
+            (.overridenBodyTypes, "Renamed to 'overriddenBodyTypes'."),
         ])
     }
 }

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -258,10 +258,11 @@ public struct ConfigOptions: Encodable {
         ///
         /// ```yaml
         /// paths:
-        ///   overridenResponses:
+        ///   overriddenResponses:
         ///     MyApiResponseType: MyCustomDecodableType
         /// ```
-        public var overridenResponses: [String: String] = [:]
+        public var overriddenResponses: [String: String] = [:]
+        public var overridenResponses: [String: String] = [:] // sourcery: skip, deprecated, message = "Renamed to 'overriddenResponses'."
 
         /// Tell CreateAPI how to map an unknown request or response content types to a Swift type used in the path generation.
         ///
@@ -269,10 +270,11 @@ public struct ConfigOptions: Encodable {
         ///
         /// ```yaml
         /// paths:
-        ///   overridenBodyTypes:
+        ///   overriddenBodyTypes:
         ///     application/octocat-stream: String
         /// ```
-        public var overridenBodyTypes: [String: String] = [:]
+        public var overriddenBodyTypes: [String: String] = [:]
+        public var overridenBodyTypes: [String: String] = [:] // sourcery: skip, deprecated, message = "Renamed to 'overriddenBodyTypes'."
 
         /// Inline simple requests, like the ones with a single parameter
         public var isInliningSimpleRequests: Bool = true

--- a/Sources/CreateOptions/GenerateOptions.swift
+++ b/Sources/CreateOptions/GenerateOptions.swift
@@ -19,6 +19,11 @@ public final class GenerateOptions {
     public static let `default` = GenerateOptions()
 
     init(configOptions: ConfigOptions = .default, warnings: [String] = []) {
+        // Support deprecated 'overriden' properties by merging any values into their 'overridden' replacement
+        var configOptions = configOptions
+        configOptions.paths.overriddenResponses.merge(configOptions.paths.overridenResponses) { new, _ in new }
+        configOptions.paths.overriddenBodyTypes.merge(configOptions.paths.overridenBodyTypes) { new, _ in new }
+
         self.configOptions = configOptions
         self.allAcronyms = Self.allAcronyms(including: configOptions.addedAcronyms, excluding: configOptions.ignoredAcronyms)
         self.warnings = warnings

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -38,9 +38,9 @@ final class GenerateTests: GenerateBaseTests {
             "--vendor", "github",
             "--config", config("""
             paths:
-              overridenResponses:
+              overriddenResponses:
                 accepted: "Void"
-              overridenBodyTypes:
+              overriddenBodyTypes:
                 application/octocat-stream: String
             rename:
               enumCases:

--- a/Tests/CreateOptionsTests/GenerateOptionsTests.swift
+++ b/Tests/CreateOptionsTests/GenerateOptionsTests.swift
@@ -25,4 +25,40 @@ final class GenerateOptionsTests: XCTestCase {
             "Found an unexpected property 'isATopLevelInvalidOption'."
         ])
     }
+
+    func testOverriddenResponsesContainsLegacyProperty() throws {
+        let options = try GenerateOptions(data: Data("""
+        paths:
+          overridenResponses:
+            A: Z
+            B: Y
+          overriddenResponses:
+            A: 0
+            C: 2
+        """.utf8))
+
+        XCTAssertEqual(options.paths.overriddenResponses, [
+            "A": "0", // Overridden from new property
+            "B": "Y", // Merged from legacy property
+            "C": "2"  // From new property
+        ])
+    }
+
+    func testOverriddenBodyTypesContainsLegacyProperty() throws {
+        let options = try GenerateOptions(data: Data("""
+        paths:
+          overridenBodyTypes:
+            A: Z
+            B: Y
+          overriddenBodyTypes:
+            A: 0
+            C: 2
+        """.utf8))
+
+        XCTAssertEqual(options.paths.overriddenBodyTypes, [
+            "A": "0", // Overridden from new property
+            "B": "Y", // Merged from legacy property
+            "C": "2"  // From new property
+        ])
+    }
 }

--- a/Tests/CreateOptionsTests/GenerateOptionsTests.swift
+++ b/Tests/CreateOptionsTests/GenerateOptionsTests.swift
@@ -10,6 +10,9 @@ final class GenerateOptionsTests: XCTestCase {
         isATopLevelInvalidOption: true
         entities:
           isANestedInvalidOption: true
+        paths:
+          overridenResponses:
+            Foo: Bar
         """.utf8)
 
         // When the options are loaded
@@ -18,6 +21,7 @@ final class GenerateOptionsTests: XCTestCase {
         // Then the appropriate warnings should be recorded
         XCTAssertEqual(options.warnings, [
             "Found an unexpected property 'isANestedInvalidOption' (in 'entities').",
+            "The property 'overridenResponses' (in 'paths') has been deprecated. Renamed to 'overriddenResponses'.",
             "Found an unexpected property 'isATopLevelInvalidOption'."
         ])
     }


### PR DESCRIPTION
- #77 

I came across a typo in the two 'overriden' config options in `paths` (missing an extra `d`). We want to rename it, but we have to be cautious that some people might have this property in their config file.

# Changes 

In this change, I rename the property, but keep the old one around as 'deprecated' so that we don't break any current usage and instead emit a warning when running the tool

> WARNING: The property 'paths.overridenResponses' has been deprecated. Renamed to 'overriddenResponses'.

