### PR TITLE
[BREAKING] Require `--split` or `--no-split` flag

### DIFF
--- a/Sources/CreateAPI/Generate.swift
+++ b/Sources/CreateAPI/Generate.swift
@@ -20,8 +20,24 @@ struct Generate: ParsableCommand {
     @Option(help: "The path to generator configuration. If not present, the command will look for .create-api.yaml in the current directory.")
     var config = "./.create-api.yaml"
 
-    @Flag(name: .shortAndLong, help: "Split output into separate files")
-    var split = false
+    @Flag(
+        name: .shortAndLong,
+        inversion: .prefixedNo,
+        help: ArgumentHelp("Split output into separate source files.", discussion: """
+
+        Merging the source files offers a compact output, but prevents the compiler \
+        from parallelizing build tasks resulting in slower builds for larger schemas.
+
+        It's recommended that you use --split, but behaviour prior to 0.1.0 matched \
+        --no-split.
+
+        In a future version, these flags will be deprecated and replaced with an \
+        alternative opt-out flag instead. For more information, see \
+        https://github.com/CreateAPI/CreateAPI/issues/74
+
+        """)
+    )
+    var split: Bool
 
     @Flag(name: .shortAndLong, help: "Print additional logging information")
     var verbose = false

--- a/Tests/CreateAPITests/GenerateBaseTests.swift
+++ b/Tests/CreateAPITests/GenerateBaseTests.swift
@@ -23,7 +23,8 @@ class GenerateBaseTests: XCTestCase {
             pathForSpec(named: name, ext: ext),
             "--output", temp.url.path,
             "--package", package ?? name,
-            "--config", self.config(config, ext: "yaml")
+            "--config", self.config(config, ext: "yaml"),
+            "--no-split" // TODO: Use --split by default
         ])
 
         // WHEN

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -9,7 +9,8 @@ final class GenerateOptionsTests: GenerateBaseTests {
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path,
             "--package", "petstore-only-schemas",
-            "--generate", "entities"
+            "--generate", "entities",
+            "--no-split" // TODO: Use --split by default
         ])
         
         // WHEN
@@ -25,7 +26,8 @@ final class GenerateOptionsTests: GenerateBaseTests {
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path,
             "--package", "petstore-change-filename",
-            "--filename-template", "%0.generated.swift"
+            "--filename-template", "%0.generated.swift",
+            "--no-split" // TODO: Use --split by default
         ])
         
         // WHEN
@@ -41,7 +43,8 @@ final class GenerateOptionsTests: GenerateBaseTests {
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path,
             "--package", "petstore-change-entityname",
-            "--entityname-template", "%0Generated"
+            "--entityname-template", "%0Generated",
+            "--no-split" // TODO: Use --split by default
         ])
         
         // WHEN
@@ -57,7 +60,8 @@ final class GenerateOptionsTests: GenerateBaseTests {
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path,
             "--package", "petstore-single-threaded",
-            "--single-threaded"
+            "--single-threaded",
+            "--no-split" // TODO: Use --split by default
         ])
         
         // WHEN
@@ -72,7 +76,8 @@ final class GenerateOptionsTests: GenerateBaseTests {
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path.appending("/petstore-no-package"),
-            "--module", "Petstore"
+            "--module", "Petstore",
+            "--no-split" // TODO: Use --split by default
         ])
         
         // WHEN
@@ -88,7 +93,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
             pathForSpec(named: "petstore", ext: "yaml"),
             "--output", temp.url.path,
             "--package", "petstore-split",
-            "--split"
+            "--split" // TODO: Use --no-split when all the other tests use --split
         ])
         
         // WHEN
@@ -102,6 +107,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-custom-imports",
             "--config", config("""
@@ -127,6 +133,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-operation-id",
             "--config", config("""
@@ -149,6 +156,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-generate-classes",
             "--config", config("""
@@ -171,6 +179,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-some-entities-as-classes",
             "--config", config("""
@@ -193,6 +202,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-some-entities-as-structs",
             "--config", config("""
@@ -216,6 +226,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-base-class",
             "--config", config("""
@@ -239,6 +250,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-disable-comments",
             "--config", config("""
@@ -261,6 +273,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-disable-init-with-coder",
             "--config", config("""
@@ -283,6 +296,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-disable-inlining",
             "--config", config("""
@@ -303,6 +317,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--generate", "entities",
             "--output", temp.url.path,
             "--package", "petstore-disable-mutable-properties",
@@ -328,6 +343,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--generate", "entities",
             "--output", temp.url.path,
             "--package", "petstore-enable-mutable-properties",
@@ -353,6 +369,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-change-namespace-when-rest-style",
             "--config", config("""
@@ -376,6 +393,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-change-namespace-when-operations-style",
             "--config", config("""
@@ -399,6 +417,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-rename-properties",
             "--config", config("""
@@ -437,6 +456,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-yaml-config",
             "--config", config("""
@@ -460,6 +480,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-change-access-control",
             "--config", config("""
@@ -480,6 +501,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-disable-acronyms",
             "--config", config("""
@@ -500,6 +522,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-disable-enums",
             "--config", config("""
@@ -520,6 +543,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-rename",
             "--config", config("""
@@ -549,6 +573,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-tabs",
             "--config", config("""
@@ -569,6 +594,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-indent-with-two-width-spaces",
             "--config", config("""
@@ -589,6 +615,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-int32-int64",
             "--config", config("""
@@ -609,6 +636,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "edgecases", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "edgecases-coding-keys",
             "--config", config("""
@@ -628,6 +656,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "strip-parent-name-nested-objects", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "strip-parent-name-nested-objects-enabled",
             "--config", config("""
@@ -647,6 +676,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "strip-parent-name-nested-objects", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "strip-parent-name-nested-objects-default"
         ])
@@ -662,6 +692,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "petstore", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--package", "petstore-identifiable",
             "--generate", "entities",

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -28,6 +28,7 @@ final class GenerateTests: GenerateBaseTests {
         // GIVEN
         let command = try Generate.parse([
             pathForSpec(named: "github", ext: "yaml"),
+            "--no-split", // TODO: Use --split by default
             "--output", temp.url.path,
             "--strict",
             "--package", "OctoKit",


### PR DESCRIPTION
# Background 

- #74 
- #57 

To help guide people to generate efficient code, we want to make splitting source code into multiple files the default behaviour. This however would be a breaking change that would bring with it potential confusion if made on its own.

Instead, we should consider making the decision to split sources a conscious one during a transitional phase.

# Changes

In this change, I update the `split` flag to remove the default value of `false` and instead define an inversion that introduces the `--no-split` flag.

This means that when running `create-api` without specifying `-s`, `--split` or `--no-split`, you will now get an error:

```
$ create-api generate schema.json 
Error: Missing one of: '--split', '--no-split'
Help:  --split <split>  Split output into separate source files.
Usage: create-api generate [<options>] <input> --split
  See 'create-api generate --help' for more information.
```

If you already used `-s` or `--split` everything is ok, but if you didn't, you will be forced to make a decision:

1. Continue with `--no-split`
2. Transition to using `--split`

To help guide users about this decision, I added some more discussion to the flag when using `--help`:

```
$ create-api generate schema.json --help
USAGE: create-api generate [<options>] <input> --split

ARGUMENTS:
  <input>                 The OpenAPI spec input file in either JSON or YAML format

OPTIONS:
  --output <output>       The output folder (default: ./.create-api/)
  --config <config>       The path to generator configuration. If not present, the
                          command will look for .create-api.yaml in the current
                          directory. (default: ./.create-api.yaml)
  -s, --split/--no-split  Split output into separate source files.

        Merging the source files offers a compact output, but prevents the compiler
        from parallelizing build tasks resulting in slower builds for larger
        schemas.

        It's recommended that you use --split, but behaviour prior to 0.1.0 matched
        --no-split.

        In a future version, these flags will be deprecated and replaced with an
        alternative opt-out flag instead. For more information, see
        https://github.com/CreateAPI/CreateAPI/issues/74

  -v, --verbose           Print additional logging information
  ...
```

As a result in 0.1.0 you are forced to make a decision. In a future version however, we will relax this again by deprecating `--split` and `--no-split` and replacing it with a more clearly named `--merge-sources` flag which defaults to `false`. 

## Release Note

- You are now required to explicitly pass the `--split` or `--no-split` flag when running the generator. `--no-split` matches the default behaviour prior to 0.1.0 but it is recommended to split your sources for improved build times of your generated code. For more information, see [#74](https://github.com/CreateAPI/CreateAPI/issues/74).