### PR TITLE
Produce better warnings when using configuration options that have been removed

### DIFF
--- a/Sourcery/DecodableWithDefault.swift.stencil
+++ b/Sourcery/DecodableWithDefault.swift.stencil
@@ -18,13 +18,18 @@ extension {{ type.name }}: Decodable {
         )
         {% endfor %}
 
-        container.recordPotentialIssues(deprecations: [
-        {% for variable in type.variables|stored %}
-        {% if variable.annotations.deprecated %}
-            (.{{ variable.name }}, "{{ variable.annotations.message }}"),
-        {% endif %}
-        {% endfor %}
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+            {% for variable in type.variables|stored|annotated:"deprecated" %}
+                ("{{ variable.name }}", "{{ variable.annotations.message }}"),
+            {% endfor %}
+            ],
+            replacements: [
+            {% for variable in type.variables|stored|annotated:"replacementFor" %}
+                ("{{ variable.annotations.replacementFor }}", "Use '{{ variable.name }}' instead."),
+            {% endfor %}
+            ]
+        )
     }
 }
 

--- a/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
+++ b/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
@@ -124,8 +124,12 @@ extension ConfigOptions: Decodable {
             defaultValue: .init()
         )
 
-        container.recordPotentialIssues(deprecations: [
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+            ],
+            replacements: [
+            ]
+        )
     }
 }
 
@@ -172,8 +176,12 @@ extension ConfigOptions.Comments: Decodable {
             defaultValue: true
         )
 
-        container.recordPotentialIssues(deprecations: [
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+            ],
+            replacements: [
+            ]
+        )
     }
 }
 
@@ -316,8 +324,12 @@ extension ConfigOptions.Entities: Decodable {
             defaultValue: []
         )
 
-        container.recordPotentialIssues(deprecations: [
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+            ],
+            replacements: [
+            ]
+        )
     }
 }
 
@@ -424,10 +436,14 @@ extension ConfigOptions.Paths: Decodable {
             defaultValue: []
         )
 
-        container.recordPotentialIssues(deprecations: [
-            (.overridenResponses, "Renamed to 'overriddenResponses'."),
-            (.overridenBodyTypes, "Renamed to 'overriddenBodyTypes'."),
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+                ("overridenResponses", "Renamed to 'overriddenResponses'."),
+                ("overridenBodyTypes", "Renamed to 'overriddenBodyTypes'."),
+            ],
+            replacements: [
+            ]
+        )
     }
 }
 
@@ -474,8 +490,12 @@ extension ConfigOptions.Rename: Decodable {
             defaultValue: [:]
         )
 
-        container.recordPotentialIssues(deprecations: [
-        ])
+        container.recordPotentialIssues(
+            deprecations: [
+            ],
+            replacements: [
+            ]
+        )
     }
 }
 

--- a/Sources/CreateOptions/IssueRecorder.swift
+++ b/Sources/CreateOptions/IssueRecorder.swift
@@ -10,7 +10,7 @@ class IssueRecorder {
     }
 
     enum IssueType {
-        case unexpected, deprecated
+        case unexpected, deprecated, unsupported
     }
 
     private(set) var issues: [Issue] = []
@@ -34,6 +34,8 @@ extension IssueRecorder.Issue: CustomStringConvertible {
         switch type {
         case .deprecated:
             summary = "The property \(propertyName) has been deprecated."
+        case .unsupported:
+            summary = "The property \(propertyName) is no longer supported."
         case .unexpected:
             summary = "Found an unexpected property \(propertyName)."
         }

--- a/Tests/CreateOptionsTests/StringCodingContainerTests.swift
+++ b/Tests/CreateOptionsTests/StringCodingContainerTests.swift
@@ -1,0 +1,61 @@
+@testable import CreateOptions
+import XCTest
+
+final class StringCodingContainerTests: XCTestCase {
+    struct Subject: Decodable {
+        enum KnownKeys: String {
+            case newProperty, deprecatedProperty
+        }
+
+        // let legacyProperty: [String]
+        let newProperty: String
+        let deprecatedProperty: String
+
+        init(from decoder: Decoder) throws {
+            let container = try StringCodingContainer<KnownKeys>(decoder: decoder)
+
+            newProperty = try container.decode(String.self, forKey: .newProperty, defaultValue: "default")
+            deprecatedProperty = try container.decode(String.self, forKey: .deprecatedProperty, defaultValue: "")
+
+            container.recordPotentialIssues(
+                deprecations: [
+                    ("deprecatedProperty", "Renamed to 'newProperty'.")
+                ],
+                replacements: [
+                    ("legacyProperty", "Use 'newProperty' instead.")
+                ]
+            )
+        }
+    }
+
+    func testIssueRecording() throws {
+        let recorder = IssueRecorder()
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .issueRecorder: recorder
+        ]
+
+        // Given JSON with legacy properties, unknown properties and deprecated properties defined
+        let data = Data("""
+        {
+          "legacyProperty": ["foo"],
+          "deprecatedProperty": "bar",
+          "unknownProperty": 1
+        }
+        """.utf8)
+
+        // When decoded
+        let subject = try decoder.decode(Subject.self, from: data)
+
+        // Then the subject is decoded as expected
+        XCTAssertEqual(subject.newProperty, "default")
+        XCTAssertEqual(subject.deprecatedProperty, "bar") // parsed from the json
+
+        // And the appropriate issues were recorded
+        XCTAssertEqual(Set(recorder.issues.map(\.description)), [
+            "The property 'legacyProperty' is no longer supported. Use 'newProperty' instead.",
+            "Found an unexpected property 'unknownProperty'.",
+            "The property 'deprecatedProperty' has been deprecated. Renamed to 'newProperty'."
+        ])
+    }
+}


### PR DESCRIPTION
In #77 we started emitting warnings for unknown properties that were found in the config options as well as deprecations:

> WARNING: The property 'overridenResponses' (in 'paths') has been deprecated. Renamed to 'overriddenResponses'.
> WARNING: Found an unexpected property 'unknownProperty'.

While the deprecations are useful, to begin with we are going to be a bit more aggressive and skip deprecating types meaning that when upgrading from 0.0.5 to 0.1.0, you'll end up seeing warnings like "Found an unexpected property 'overridenResponses' (in 'paths')."

This might initially be confusing to the user since it use to work. The aim of this change is to tweak the messaging to better support direct replacements without deprecation.

With this change, a user defining `overridenResponses` in the config will now see the following:

> The property 'overridenResponses' (in 'paths') is no longer supported. Use 'overriddenResponses' instead.

Its mostly similar to the deprecation besides one thing: it doesn't assume the property was only renamed (i.e the behaviour could change). Its just a small helper to improve the developer experience. 