### PR TITLE
Remove deprecated `overridenResponses` and `overridenBodyTypes` properties

### DIFF
--- a/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
+++ b/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
@@ -341,9 +341,7 @@ extension ConfigOptions.Paths: Decodable {
         case isAddingOperationIds
         case imports
         case overriddenResponses
-        case overridenResponses
         case overriddenBodyTypes
-        case overridenBodyTypes
         case isInliningSimpleRequests
         case isInliningSimpleQueryParameters
         case simpleQueryParametersThreshold
@@ -386,18 +384,8 @@ extension ConfigOptions.Paths: Decodable {
             defaultValue: [:]
         )
 
-        overridenResponses = try container.decode([String: String].self,
-            forKey: .overridenResponses,
-            defaultValue: [:]
-        )
-
         overriddenBodyTypes = try container.decode([String: String].self,
             forKey: .overriddenBodyTypes,
-            defaultValue: [:]
-        )
-
-        overridenBodyTypes = try container.decode([String: String].self,
-            forKey: .overridenBodyTypes,
             defaultValue: [:]
         )
 
@@ -438,10 +426,10 @@ extension ConfigOptions.Paths: Decodable {
 
         container.recordPotentialIssues(
             deprecations: [
-                ("overridenResponses", "Renamed to 'overriddenResponses'."),
-                ("overridenBodyTypes", "Renamed to 'overriddenBodyTypes'."),
             ],
             replacements: [
+                ("overridenResponses", "Use 'overriddenResponses' instead."),
+                ("overridenBodyTypes", "Use 'overriddenBodyTypes' instead."),
             ]
         )
     }

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -277,8 +277,7 @@ public struct ConfigOptions: Encodable {
         ///   overriddenResponses:
         ///     MyApiResponseType: MyCustomDecodableType
         /// ```
-        public var overriddenResponses: [String: String] = [:]
-        public var overridenResponses: [String: String] = [:] // sourcery: skip, deprecated, message = "Renamed to 'overriddenResponses'."
+        public var overriddenResponses: [String: String] = [:] // sourcery: replacementFor = overridenResponses
 
         /// Tell CreateAPI how to map an unknown request or response content types to a Swift type used in the path generation.
         ///
@@ -289,8 +288,7 @@ public struct ConfigOptions: Encodable {
         ///   overriddenBodyTypes:
         ///     application/octocat-stream: String
         /// ```
-        public var overriddenBodyTypes: [String: String] = [:]
-        public var overridenBodyTypes: [String: String] = [:] // sourcery: skip, deprecated, message = "Renamed to 'overriddenBodyTypes'."
+        public var overriddenBodyTypes: [String: String] = [:] // sourcery: replacementFor = overridenBodyTypes
 
         /// Inline simple requests, like the ones with a single parameter
         public var isInliningSimpleRequests: Bool = true

--- a/Sources/CreateOptions/GenerateOptions.swift
+++ b/Sources/CreateOptions/GenerateOptions.swift
@@ -19,11 +19,6 @@ public final class GenerateOptions {
     public static let `default` = GenerateOptions()
 
     init(configOptions: ConfigOptions = .default, warnings: [String] = []) {
-        // Support deprecated 'overriden' properties by merging any values into their 'overridden' replacement
-        var configOptions = configOptions
-        configOptions.paths.overriddenResponses.merge(configOptions.paths.overridenResponses) { new, _ in new }
-        configOptions.paths.overriddenBodyTypes.merge(configOptions.paths.overridenBodyTypes) { new, _ in new }
-
         self.configOptions = configOptions
         self.allAcronyms = Self.allAcronyms(including: configOptions.addedAcronyms, excluding: configOptions.ignoredAcronyms)
         self.warnings = warnings

--- a/Tests/CreateOptionsTests/GenerateOptionsTests.swift
+++ b/Tests/CreateOptionsTests/GenerateOptionsTests.swift
@@ -21,44 +21,8 @@ final class GenerateOptionsTests: XCTestCase {
         // Then the appropriate warnings should be recorded
         XCTAssertEqual(options.warnings, [
             "Found an unexpected property 'isANestedInvalidOption' (in 'entities').",
-            "The property 'overridenResponses' (in 'paths') has been deprecated. Renamed to 'overriddenResponses'.",
+            "The property 'overridenResponses' (in 'paths') is no longer supported. Use 'overriddenResponses' instead.",
             "Found an unexpected property 'isATopLevelInvalidOption'."
-        ])
-    }
-
-    func testOverriddenResponsesContainsLegacyProperty() throws {
-        let options = try GenerateOptions(data: Data("""
-        paths:
-          overridenResponses:
-            A: Z
-            B: Y
-          overriddenResponses:
-            A: 0
-            C: 2
-        """.utf8))
-
-        XCTAssertEqual(options.paths.overriddenResponses, [
-            "A": "0", // Overridden from new property
-            "B": "Y", // Merged from legacy property
-            "C": "2"  // From new property
-        ])
-    }
-
-    func testOverriddenBodyTypesContainsLegacyProperty() throws {
-        let options = try GenerateOptions(data: Data("""
-        paths:
-          overridenBodyTypes:
-            A: Z
-            B: Y
-          overriddenBodyTypes:
-            A: 0
-            C: 2
-        """.utf8))
-
-        XCTAssertEqual(options.paths.overriddenBodyTypes, [
-            "A": "0", // Overridden from new property
-            "B": "Y", // Merged from legacy property
-            "C": "2"  // From new property
         ])
     }
 }


### PR DESCRIPTION
For 0.1.0 we're going be a bit more aggressive so instead of deprecating properties in the configuration file, we're just going to directly remove support for them meaning that there will instead be migration steps involved.

In #78, I replaced `overridenResponses` and `overridenBodyTypes` with properties that corrected the typos and with that I marked the old ones as deprecated and made sure that they continued to work. Now however, I'm just removing them.

This means that in 0.1.0 the user will have to fix this typo themselves if they are using the properties in their configuration. 

## Release Note

- The `paths.overridenResponses` property has been renamed to `paths.overriddenResponses`
- The `paths.overridenBodyTypes` property has been renamed to `paths.overriddenBodyTypes`