### PR TITLE
Remove `isAdditionalPropertiesOnByDefault` 

### DIFF
--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -84,7 +84,6 @@ Below you can find the complete documentation for all available options.
   - [optimizeCodingKeys](#entitiesoptimizecodingkeys)
   - [defaultValues](#entitiesdefaultvalues)
   - [inlineReferencedSchemas](#entitiesinlinereferencedschemas)
-  - [isAdditionalPropertiesOnByDefault](#entitiesisadditionalpropertiesonbydefault)
   - [stripParentNameInNestedObjects](#entitiesstripparentnameinnestedobjects)
   - [exclude](#entitiesexclude)
   - [include](#entitiesinclude)
@@ -476,15 +475,6 @@ If set to `true`, uses the `default` value from the schema for the generated pro
 **Default:** `false`
 
 For `allOf` inline properties from references
-
-<br/>
-
-## entities.isAdditionalPropertiesOnByDefault
-
-**Type:** Bool<br />
-**Default:** `true`
-
-Changes how unspecified additional properties are interpreted
 
 <br/>
 

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -396,14 +396,8 @@ extension Generator {
     // Creates a dictionary, e.g. `[ String: AnyJSON]`, `[String: [String: String]]`,
     // `[String: CustomNestedType]`. Returns `Void` if no properties are allowed.
     private func makeDictionary(key: String, info: JSONSchemaContext, details: JSONSchema.ObjectContext, context: Context) throws -> AdditionalProperties? {
-        var additional = details.additionalProperties
-        if details.properties.isEmpty, options.entities.isAdditionalPropertiesOnByDefault {
-            additional = additional ?? .a(true)
-        }
-        guard let additional = additional else {
-            return nil
-        }
-        switch additional {
+        let additionalProperties = details.additionalProperties ?? .a(true)
+        switch additionalProperties {
         case .a(let allowed):
             if !allowed && details.properties.isEmpty {
                 return AdditionalProperties(type: .builtin("Void"), info: info)

--- a/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
+++ b/Sources/CreateOptions/ConfigOptions+DecodableWithDefault.swift
@@ -212,7 +212,6 @@ extension ConfigOptions.Entities: Decodable {
         case optimizeCodingKeys
         case defaultValues
         case inlineReferencedSchemas
-        case isAdditionalPropertiesOnByDefault
         case stripParentNameInNestedObjects
         case exclude
         case include
@@ -311,11 +310,6 @@ extension ConfigOptions.Entities: Decodable {
             defaultValue: false
         )
 
-        isAdditionalPropertiesOnByDefault = try container.decode(Bool.self,
-            forKey: .isAdditionalPropertiesOnByDefault,
-            defaultValue: true
-        )
-
         stripParentNameInNestedObjects = try container.decode(Bool.self,
             forKey: .stripParentNameInNestedObjects,
             defaultValue: false
@@ -349,6 +343,7 @@ extension ConfigOptions.Entities: Decodable {
                 ("isAddingDefaultValues", "Use 'defaultValues' instead."),
                 ("isInliningPropertiesFromReferencedSchemas", "Use 'inlineReferencedSchemas' instead."),
                 ("isStrippingParentNameInNestedObjects", "Use 'stripParentNameInNestedObjects' instead."),
+                ("isAdditionalPropertiesOnByDefault", "Enabled by default."),
             ]
         )
     }

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -143,6 +143,7 @@ public struct ConfigOptions: Encodable {
     public var entities: Entities = .init()
 
     // sourcery: document, decodableWithDefault
+    // sourcery: removed: isAdditionalPropertiesOnByDefault = "Enabled by default."
     /// Options specifically related to generating entities
     public struct Entities: Encodable {
         /// When true, generates entities as `struct` types. Otherwise generates them as `class` types.
@@ -204,9 +205,6 @@ public struct ConfigOptions: Encodable {
         // TODO: Improve this documentation
         /// For `allOf` inline properties from references
         public var inlineReferencedSchemas: Bool = false // sourcery: replacementFor = isInliningPropertiesFromReferencedSchemas
-
-        /// Changes how unspecified additional properties are interpreted
-        public var isAdditionalPropertiesOnByDefault: Bool = true
 
         /// Strips the parent name of enum cases within objects that are `oneOf` / `allOf` / `anyOf` of nested references
         public var stripParentNameInNestedObjects: Bool = false // sourcery: replacementFor = isStrippingParentNameInNestedObjects


### PR DESCRIPTION
- Closes #93 

If I understand the schema correctly, we don't need to worry about `additionalProperties` meaning anything other than `true` when it's not specified because this is documented in the OpenAPI spec:

> - `additionalProperties` - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](https://swagger.io/specification/#schema-object) and not a standard JSON Schema. **Consistent with JSON Schema, `additionalProperties` defaults to `true`.**

This would mean that `isAdditionalPropertiesOnByDefault` is redundant. Therefore I am removing it and making it's behaviour when `true` the default. 