### PR TITLE
Refactor responsibility of writing generated output out of `Generate` command

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Package.swift
+++ b/Sources/CreateAPI/Generator/Generator+Package.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension Generator {
+    func package(named name: String?) -> (name: String, manifest: GeneratedFile)? {
+        guard let name = name else { return nil }
+        let manifest = GeneratedFile(name: "Package", contents: makePackageFile(name: name))
+        return (name, manifest)
+    }
+
     func makePackageFile(name: String) -> String {
         let packages: String = [
             #".package(url: "https://github.com/kean/Get", from: "1.0.2")"#,

--- a/Sources/CreateAPI/Output/Output.swift
+++ b/Sources/CreateAPI/Output/Output.swift
@@ -14,42 +14,42 @@ struct Output {
         let rootWriter = try OutputWriter(outputURL: outputURL)
 
         // Write the Package.swift manifest file, or figure out the writer for source files
-        let sourceWriter: OutputWriter
+        let sourcesWriter: OutputWriter
         if let package = package {
             let packageWriter = rootWriter.writer(in: package.name)
             // TODO: Use `write(file:header:template:options:)` to match indentation for Package.swift?
             try packageWriter.write(package.manifest.contents, to: "\(package.manifest.name).swift")
 
-            sourceWriter = packageWriter.writer(in: "Sources")
+            sourcesWriter = packageWriter.writer(in: "Sources")
         } else {
-            sourceWriter = rootWriter
+            sourcesWriter = rootWriter
         }
 
         // Write paths into the source directory
         if let paths = paths {
-            try write(paths, to: sourceWriter, group: "Paths", template: options.paths.filenameTemplate)
+            try write(paths, to: sourcesWriter, group: "Paths", template: options.paths.filenameTemplate)
         }
 
         // Write entities into the source directory
         if let entities = entities {
-            try write(entities, to: sourceWriter, group: "Entities", template: options.entities.filenameTemplate)
+            try write(entities, to: sourcesWriter, group: "Entities", template: options.entities.filenameTemplate)
         }
     }
 
-    private func write(_ output: GeneratorOutput, to writer: OutputWriter, group: String, template: String) throws {
+    private func write(_ output: GeneratorOutput, to sourcesWriter: OutputWriter, group: String, template: String) throws {
         let template = Template(template)
         if mergeSources {
             let merged = GeneratedFile(name: group, merging: output.files)
-            try writer.write(file: merged, header: output.header, template: template, options: options)
+            try sourcesWriter.write(file: merged, header: output.header, template: template, options: options)
         } else {
-            let writer = writer.writer(in: group)
+            let groupWriter = sourcesWriter.writer(in: group)
             for file in output.files {
-                try writer.write(file: file, header: output.header, template: template, options: options)
+                try groupWriter.write(file: file, header: output.header, template: template, options: options)
             }
         }
 
         for file in output.extensions {
-            try writer.write(file: file, header: output.header, options: options)
+            try sourcesWriter.write(file: file, header: output.header, options: options)
         }
     }
 }

--- a/Sources/CreateAPI/Output/Output.swift
+++ b/Sources/CreateAPI/Output/Output.swift
@@ -17,7 +17,8 @@ struct Output {
         let sourceWriter: OutputWriter
         if let package = package {
             let packageWriter = rootWriter.writer(in: package.name)
-            try packageWriter.write(file: package.manifest, options: options)
+            // TODO: Use `write(file:header:template:options:)` to match indentation for Package.swift?
+            try packageWriter.write(package.manifest.contents, to: "\(package.manifest.name).swift")
 
             sourceWriter = packageWriter.writer(in: "Sources")
         } else {

--- a/Sources/CreateAPI/Output/Output.swift
+++ b/Sources/CreateAPI/Output/Output.swift
@@ -1,0 +1,77 @@
+import CreateOptions
+import Foundation
+
+struct Output {
+    let paths: GeneratorOutput?
+    let entities: GeneratorOutput?
+    let package: (name: String, manifest: GeneratedFile)?
+    let options: GenerateOptions
+    let mergeSources: Bool // Will soon be internal to GenerateOptions
+
+    /// Writes the output into the given directory.
+    func write(to outputURL: URL) throws {
+        // Create the output writer and begin
+        let rootWriter = try OutputWriter(outputURL: outputURL)
+
+        // Write the Package.swift manifest file, or figure out the writer for source files
+        let sourceWriter: OutputWriter
+        if let package = package {
+            let packageWriter = rootWriter.writer(in: package.name)
+            try packageWriter.write(file: package.manifest, options: options)
+
+            sourceWriter = packageWriter.writer(in: "Sources")
+        } else {
+            sourceWriter = rootWriter
+        }
+
+        // Write paths into the source directory
+        if let paths = paths {
+            try write(paths, to: sourceWriter, group: "Paths", template: options.paths.filenameTemplate)
+        }
+
+        // Write entities into the source directory
+        if let entities = entities {
+            try write(entities, to: sourceWriter, group: "Entities", template: options.entities.filenameTemplate)
+        }
+    }
+
+    private func write(_ output: GeneratorOutput, to writer: OutputWriter, group: String, template: String) throws {
+        let template = Template(template)
+        if mergeSources {
+            let merged = GeneratedFile(name: group, merging: output.files)
+            try writer.write(file: merged, header: output.header, template: template, options: options)
+        } else {
+            let writer = writer.writer(in: group)
+            for file in output.files {
+                try writer.write(file: file, header: output.header, template: template, options: options)
+            }
+        }
+
+        for file in output.extensions {
+            try writer.write(file: file, header: output.header, options: options)
+        }
+    }
+}
+
+private extension OutputWriter {
+    func write(
+        file: GeneratedFile,
+        header: String? = nil,
+        template: Template = Template("%0.swift"),
+        options: GenerateOptions
+    ) throws {
+        let contents = [header, file.contents].compactMap({ $0 }).joined(separator: "\n\n")
+        let formatted = contents.indent(using: options).appending("\n")
+
+        let filename = template.substitute(file.name)
+
+        try write(formatted, to: filename)
+    }
+}
+
+private extension GeneratedFile {
+    /// Merges the contents of multiple files into a single file with the given name
+    init(name: String, merging files: [GeneratedFile]) {
+        self.init(name: name, contents: files.map(\.contents).joined(separator: "\n\n"))
+    }
+}

--- a/Sources/CreateAPI/Output/OutputWriter.swift
+++ b/Sources/CreateAPI/Output/OutputWriter.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A utility tool for writing multiple source files into a directory (and subdirectories)
+class OutputWriter {
+    typealias Writer = (_ contents: String, _ components: [String]) throws -> Void
+    let pathComponents: [String]
+    let performWrite: Writer
+
+    convenience init(outputURL: URL, fileManger: FileManager = .default) throws {
+        // Ensure the outputURL is not a file
+        var isDirectory = ObjCBool(false)
+        if fileManger.fileExists(atPath: outputURL.path, isDirectory: &isDirectory) && !isDirectory.boolValue {
+            throw GeneratorError("output cannot be a file")
+        }
+
+        // Record the output paths to warn when mistakenly overwriting
+        var writtenPaths: Set<String> = []
+
+        // Create the initial writer
+        self.init(pathComponents: []) { contents, pathComponents in
+            let subpath = pathComponents.joined(separator: "/")
+            if writtenPaths.contains(subpath) {
+                throw GeneratorError("Attempting to overwrite contents of \(subpath)")
+            }
+
+            // Create the subdirectory if it doesn't already exist
+            let fileURL = outputURL.appending(path: subpath)
+            let directoryURL = fileURL.deletingLastPathComponent()
+            try directoryURL.createDirectoryIfNeeded()
+
+            // Write the source to file
+            print("Writing to", subpath)
+            try contents.write(to: fileURL)
+            writtenPaths.insert(subpath)
+        }
+    }
+
+    private init(pathComponents: [String], performWrite: @escaping Writer) {
+        self.pathComponents = pathComponents
+        self.performWrite = performWrite
+    }
+
+    /// Writes the contents of a string to a file with the given name in the current directory
+    func write(_ contents: String, to filename: String) throws {
+        let components = pathComponents + [filename]
+        try performWrite(contents, components)
+    }
+
+    /// Returns a new writer for writing in the given subdirectory
+    func writer(in subdirectory: String...) -> OutputWriter {
+        OutputWriter(pathComponents: pathComponents + subdirectory, performWrite: performWrite)
+    }
+}


### PR DESCRIPTION
- #116 
- #88 

In some upcoming changes I want to make adjustments to the logic around writing outputs but I had a bit of a hard time with the way things were currently written. For that reason, I think it was time for a bit of a cleanup 🙂 

In this change, I bring in two new types:

1. `OutputWriter`, a small and generic class that helps make it easy to write files out into various directory structures. It's completely generic and not tied to any generator implementation details and does a few other things like throw errors if you try writing a file to the same location twice.
2. `Output`, basically a wrapper around the two `GeneratorOutput`'s that also includes the generated Package.swift manifest and the relevant `GenerateOptions`. It provides a nice isolated location for us the new `write(to:)` method that interacts with `OutputWriter` and writes the appropriate files to the filesystem.

While I didn't write any tests for these types directly, the overall generator test fixtures remain unchanged which is good proof that it results in an identical output. 