### PR TITLE
Cleanup tests with new snapshot method

### DIFF
--- a/Tests/CreateAPITests/GenerateFeaturesTests.swift
+++ b/Tests/CreateAPITests/GenerateFeaturesTests.swift
@@ -3,6 +3,12 @@ import XCTest
 
 final class GenerateFeaturesTests: GenerateBaseTests {    
     func testQueryParameters() throws {
-        try testSpec(name: "test-query-parameters", ext: "yaml")
+        try snapshot(
+            spec: .testQueryParameters,
+            name: "test-query-parameters",
+            arguments: [
+                "--package", "test-query-parameters"
+            ]
+        )
     }
 }

--- a/Tests/CreateAPITests/GenerateFeaturesTests.swift
+++ b/Tests/CreateAPITests/GenerateFeaturesTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import create_api
 
-final class GenerateFeaturesTests: GenerateBaseTests {    
+final class GenerateFeaturesTests: GenerateTestCase {    
     func testQueryParameters() throws {
         try snapshot(
             spec: .testQueryParameters,

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import create_api
 
-final class GenerateOptionsTests: GenerateBaseTests {
+final class GenerateOptionsTests: GenerateTestCase {
     func testPestoreOnlySchemas() throws {
         try snapshot(
             spec: .petstore,

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -3,91 +3,67 @@ import XCTest
 
 final class GenerateOptionsTests: GenerateBaseTests {
     func testPestoreOnlySchemas() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-only-schemas",
-            "--generate", "entities"
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-only-schemas")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-only-schemas",
+            arguments: [
+                "--package", "petstore-only-schemas",
+                "--generate", "entities"
+            ]
+        )
     }
     
     func testPetsStoreChangeEntityname() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-change-entityname",
-            "--entityname-template", "%0Generated"
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-change-entityname")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-change-entityname",
+            arguments: [
+                "--package", "petstore-change-entityname",
+                "--entityname-template", "%0Generated"
+            ]
+        )
     }
     
     func testPestoreSingleThreaded() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-single-threaded",
-            "--single-threaded"
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-single-threaded")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-single-threaded",
+            arguments: [
+                "--package", "petstore-single-threaded",
+                "--single-threaded"
+            ]
+        )
     }
     
     func testPetstoreDisablePackages() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path.appending("/petstore-no-package"),
-            "--module", "Petstore"
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-no-package")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-no-package",
+            arguments: [
+                "--module", "Petstore"
+            ]
+        )
     }
     
     func testPetstoreMergeSources() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-merge-sources",
-            "--merge-sources"
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-merge-sources")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-merge-sources",
+            arguments: [
+                "--package", "petstore-merge-sources",
+                "--merge-sources"
+            ]
+        )
     }
     
     func testPestoreAddCustomImport() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-custom-imports",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-custom-imports",
+            arguments: [
+                "--package", "petstore-custom-imports"
+            ],
+            configuration: """
             {
                 "paths": {
                     "imports": ["Get", "HTTPHeaders", "CoreData"]
@@ -96,45 +72,35 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     "imports": ["CoreLocation"]
                 }
             }
-            """)
-        ])
-
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-custom-imports")
+            """
+        )
     }
         
     func testPestoreGenerateClasses() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-generate-classes",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-generate-classes",
+            arguments: [
+                "--package", "petstore-generate-classes"
+            ],
+            configuration: """
             {
                 "entities": {
                     "defaultType": "finalClass"
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-generate-classes")
+            """
+        )
     }
     
     func testPestoreSomeEntitiesAsClasses() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-some-entities-as-classes",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-some-entities-as-classes",
+            arguments: [
+                "--package", "petstore-some-entities-as-classes"
+            ],
+            configuration: """
             {
                 "entities": {
                     "typeOverrides": {
@@ -142,23 +108,18 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     }
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-some-entities-as-classes")
+            """
+        )
     }
     
     func testPetstoreOverrideGenerateAsStructs() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-some-entities-as-structs",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-some-entities-as-structs",
+            arguments: [
+                "--package", "petstore-some-entities-as-structs",
+            ],
+            configuration: """
             {
                 "entities": {
                     "defaultType": "finalClass",
@@ -167,109 +128,84 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     }
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-some-entities-as-structs")
+            """
+        )
     }
     
     func testPetstoreBaseClass() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-base-class",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-base-class",
+            arguments: [
+                "--package", "petstore-base-class"
+            ],
+            configuration: """
             {
                 "entities": {
                     "defaultType": "finalClass",
                     "baseClass": "NSObject"
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-base-class")
+            """
+        )
     }
     
     func testPetstoreDisableCommentsGeneration() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-disable-comments",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-disable-comments",
+            arguments: [
+                "--package", "petstore-disable-comments"
+            ],
+            configuration: """
             {
                 "commentOptions": false
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-disable-comments")
+            """
+        )
     }
     
     func testPetstoreDisableInitWithCoder() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-disable-init-with-coder",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-disable-init-with-coder",
+            arguments: [
+                "--package", "petstore-disable-init-with-coder"
+            ],
+            configuration: """
             {
                 "entities": {
                     "alwaysIncludeDecodableImplementation": false
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-disable-init-with-coder")
+            """
+        )
     }
     
     func testPetstoreDisableInlining() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-disable-inlining",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-disable-inlining",
+            arguments: [
+                "--package", "petstore-disable-inlining"
+            ],
+            configuration: """
             {
                 "inlineTypealiases": false
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-disable-inlining")
+            """
+        )
     }
     
     func testPetstoreDisableMutableProperties() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--generate", "entities",
-            "--output", temp.url.path,
-            "--package", "petstore-disable-mutable-properties",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-disable-mutable-properties",
+            arguments: [
+                "--package", "petstore-disable-mutable-properties",
+                "--generate", "entities",
+            ],
+            configuration: """
             {
                 "entities": {
                     "typeOverrides": {
@@ -278,24 +214,19 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     "mutableProperties": false
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-disable-mutable-properties")
+            """
+        )
     }
     
     func testPetstoreEnableMutableProperties() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--generate", "entities",
-            "--output", temp.url.path,
-            "--package", "petstore-enable-mutable-properties",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-enable-mutable-properties",
+            arguments: [
+                "--package", "petstore-enable-mutable-properties",
+                "--generate", "entities",
+            ],
+            configuration: """
             {
                 "entities": {
                     "typeOverrides": {
@@ -304,87 +235,67 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     "mutableProperties": ["classes", "structs"],
                 }
             }
-            """)
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-enable-mutable-properties")
+            """
+        )
     }
 
     func testPetstoreChangeNamespaceWhenRestStyle() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-change-namespace-when-rest-style",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-change-namespace-when-rest-style",
+            arguments: [
+                "--package", "petstore-change-namespace-when-rest-style"
+            ],
+            configuration: """
             {
                 "paths": {
                     "style": "rest",
                     "namespace": "Namespace",
                 }
             }
-            """)
-        ])
-
-        // WHEN
-        try command.run()
-
-        // THEN
-        try compare(package: "petstore-change-namespace-when-rest-style")
+            """
+        )
     }
 
     func testPetstoreChangeNamespaceWhenOperationsStyle() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-change-namespace-when-operations-style",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-change-namespace-when-operations-style",
+            arguments: [
+                "--package", "petstore-change-namespace-when-operations-style"
+            ],
+            configuration: """
             {
                 "paths": {
                     "style": "operations",
                     "namespace": "Namespace",
                 }
             }
-            """)
-        ])
-
-        // WHEN
-        try command.run()
-
-        // THEN
-        try compare(package: "petstore-change-namespace-when-operations-style")
+            """
+        )
     }
     
     func testPetstoreInternalAccessControl() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-change-access-control",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-change-access-control",
+            arguments: [
+                "--package", "edgecases-change-access-control"
+            ],
+            configuration: """
             access: internal
-            """, ext: "yaml")
-            ])
-            
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-change-access-control")
+            """
+        )
     }
         
-    func testEdgecasesRenamePrperties() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-rename-properties",
-            "--config", config("""
+    func testEdgecasesRenameProperties() throws {
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-rename-properties",
+            arguments: [
+                "--package", "edgecases-rename-properties"
+            ],
+            configuration: """
             {
                 "rename": {
                     "properties": {
@@ -395,97 +306,67 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     }
                 }
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        //
-        // 1) "Category.name": "title",
-        // Only Categy.name should be affected, but not anything else, e.g. Tag.name
-        //
-        // 2) "Pet.status": "state"
-        // Check that enum name also changes
-        //
-        // 3) "complete": "isDone"
-        // // Applied before boolean logic
-        
-        try compare(package: "edgecases-rename-properties")
+            """
+        )
     }
     
     
     func testEdgecasesPassYAMLConfiguration() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-yaml-config",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-yaml-config",
+            arguments: [
+                "--package", "edgecases-yaml-config"
+            ],
+            configuration: """
             rename:
                 properties:
                     id: identifier
                     Category.name: title
                     Pet.status: state
                     complete: isDone
-            """, ext: "yaml")
-            ])
-            
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-yaml-config")
+            """
+        )
     }
                     
     func testEdgecasesDisableAcronyms() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-disable-acronyms",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-disable-acronyms",
+            arguments: [
+                "--package", "edgecases-disable-acronyms"
+            ],
+            configuration: """
             {
                 "acronyms": []
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-disable-acronyms")
+            """
+        )
     }
     
     func testEdgecasesDisableEnumGeneration() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-disable-enums",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-disable-enums",
+            arguments: [
+                "--package", "edgecases-disable-enums"
+            ],
+            configuration: """
             {
                 "generateEnums": false
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-disable-enums")
+            """
+        )
     }
     
     func testEdgecasesRename() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-rename",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-rename",
+            arguments: [
+                "--package", "edgecases-rename"
+            ],
+            configuration: """
             {
                 "rename": {
                     "properties": {
@@ -497,182 +378,136 @@ final class GenerateOptionsTests: GenerateBaseTests {
                     }
                 }
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        // "Status" is not affected because it's an enum
-        try compare(package: "edgecases-rename")
+            """
+        )
     }
     
     func testEdgecasesIndentWithTabs() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-tabs",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-tabs",
+            arguments: [
+                "--package", "edgecases-tabs"
+            ],
+            configuration: """
             {
                 "indentation": "tabs"
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-tabs")
+            """
+        )
     }
     
     func testEdgecasesIndentWithTwoWidthSpaces() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-indent-with-two-width-spaces",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-indent-with-two-width-spaces",
+            arguments: [
+                "--package", "edgecases-indent-with-two-width-spaces"
+            ],
+            configuration: """
             {
                 "spaceWidth": 2
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-indent-with-two-width-spaces")
+            """
+        )
     }
     
     func testEdgecasesEnableIntegerCapacity() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-int32-int64",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-int32-int64",
+            arguments: [
+                "--package", "edgecases-int32-int64"
+            ],
+            configuration: """
             {
                 "useFixWidthIntegers": true
             }
-            """)
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-int32-int64")
+            """
+        )
     }
     
     func testEdgecasesGenerateCodingKeys() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "edgecases", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "edgecases-coding-keys",
-            "--config", config("""
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-coding-keys",
+            arguments: [
+                "--package", "edgecases-coding-keys"
+            ],
+            configuration: """
             entities:
                 optimizeCodingKeys: false
-            """, ext: "yaml")
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "edgecases-coding-keys")
+            """
+        )
     }
 
     func testStripNamePrefixNestedObjectsEnabled() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "strip-parent-name-nested-objects", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "strip-parent-name-nested-objects-enabled",
-            "--config", config("""
+        try snapshot(
+            spec: .stripParentNameNestedObjects,
+            name: "strip-parent-name-nested-objects-enabled",
+            arguments: [
+                "--package", "strip-parent-name-nested-objects-enabled"
+            ],
+            configuration: """
             entities:
                 stripParentNameInNestedObjects: true
-            """, ext: "yaml")
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "strip-parent-name-nested-objects-enabled")
+            """
+        )
     }  
 
     func testStripNamePrefixNestedObjects() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "strip-parent-name-nested-objects", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "strip-parent-name-nested-objects-default"
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "strip-parent-name-nested-objects-default")
+        try snapshot(
+            spec: .stripParentNameNestedObjects,
+            name: "strip-parent-name-nested-objects-default",
+            arguments: [
+                "--package", "strip-parent-name-nested-objects-default"
+            ]
+        )
     }
     
     func testPetstoreIdentifiableEnabled() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-identifiable",
-            "--generate", "entities",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-identifiable",
+            arguments: [
+                "--package", "petstore-identifiable",
+                "--generate", "entities"
+            ],
+            configuration: """
             entities:
                 includeIdentifiableConformance: true
             rename:
                 properties:
                     Error.code: id
-            """, ext: "yaml")
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-identifiable")
+            """
+        )
     }
     
     func testPetstoreFilenameTemplate() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-filename-template",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-filename-template",
+            arguments: [
+                "--package", "petstore-filename-template"
+            ],
+            configuration: """
             entities:
                 filenameTemplate: "%0Model.swift"
             paths:
                 filenameTemplate: "%0API.swift"
-            """, ext: "yaml")
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-filename-template")
+            """
+        )
     }
     
     func testPetstoreEntityExclude() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "petstore", ext: "yaml"),
-            "--output", temp.url.path,
-            "--package", "petstore-entity-exclude",
-            "--generate", "entities",
-            "--config", config("""
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-entity-exclude",
+            arguments: [
+                "--package", "petstore-entity-exclude",
+                "--generate", "entities",
+            ],
+            configuration: """
             entities:
                 exclude:
                 - Error
@@ -682,13 +517,7 @@ final class GenerateOptionsTests: GenerateBaseTests {
                 properties:
                     Pet.id: notID
                     Pet.name: id
-            """, ext: "yaml")
-        ])
-        
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "petstore-entity-exclude")
+            """
+        )
     }
 }

--- a/Tests/CreateAPITests/GenerateTestCase.swift
+++ b/Tests/CreateAPITests/GenerateTestCase.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import create_api
 
-class GenerateBaseTests: XCTestCase {
+class GenerateTestCase: XCTestCase {
     struct SpecFixture {
         let name: String
         let ext: String

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -3,35 +3,61 @@ import XCTest
 
 final class GenerateTests: GenerateBaseTests {
     func testPestore() throws {
-        try testSpec(name: "petstore", ext: "yaml", package: "petstore-default")
+        try snapshot(
+            spec: .petstore,
+            name: "petstore-default",
+            arguments: [
+                "--package", "petstore-default"
+            ]
+        )
     }
     
     func testEdgecases() throws {
-        try testSpec(name: "edgecases", ext: "yaml", package: "edgecases-default")
+        try snapshot(
+            spec: .edgecases,
+            name: "edgecases-default",
+            arguments: [
+                "--package", "edgecases-default"
+            ]
+        )
     }
 
     func testInlining() throws {
-        try testSpec(name: "inlining", ext: "yaml", package: "inlining-default", config: """
-        entities:
-          inlineReferencedSchemas: true
-          typeOverrides:
-            Letter: finalClass
-        """)
+        try snapshot(
+            spec: .inlining,
+            name: "inlining-default",
+            arguments: [
+                "--package", "inlining-default"
+            ],
+            configuration: """
+            entities:
+              inlineReferencedSchemas: true
+              typeOverrides:
+                Letter: finalClass
+            """
+        )
     }
 
     func testDiscriminator() throws {
-        try testSpec(name: "discriminator", ext: "yaml", package: "discriminator")
+        try snapshot(
+            spec: .discriminator,
+            name: "discriminator",
+            arguments: [
+                "--package", "discriminator"
+            ]
+        )
     }    
     
     func testGitHub() throws {
-        // GIVEN
-        let command = try Generate.parse([
-            pathForSpec(named: "github", ext: "yaml"),
-            "--output", temp.url.path,
-            "--strict",
-            "--package", "OctoKit",
-            "--vendor", "github",
-            "--config", config("""
+        try snapshot(
+            spec: .github,
+            name: "OctoKit",
+            arguments: [
+                "--strict",
+                "--package", "OctoKit",
+                "--vendor", "github"
+            ],
+            configuration: """
             paths:
               overriddenResponses:
                 accepted: "Void"
@@ -41,17 +67,17 @@ final class GenerateTests: GenerateBaseTests {
               enumCases:
                 reactions-+1: "reactionsPlusOne"
                 reactions--1: "reactionsMinusOne"
-            """, ext: "yaml")
-        ])
-                
-        // WHEN
-        try command.run()
-        
-        // THEN
-        try compare(package: "OctoKit")
+            """
+        )
     }
 
     func testCookpad() throws {
-        try testSpec(name: "cookpad", ext: "json")
+        try snapshot(
+            spec: .cookpad,
+            name: "cookpad",
+            arguments: [
+                "--package", "cookpad"
+            ]
+        )
     }
 }

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import create_api
 
-final class GenerateTests: GenerateBaseTests {
+final class GenerateTests: GenerateTestCase {
     func testPestore() throws {
         try snapshot(
             spec: .petstore,


### PR DESCRIPTION
- related #88 

Prior to now, the tests would generate and assert snapshots in a relatively verbose way which gets tricky around file paths. This would make my job harder when adjusting behaviour on #88 so instead I decided to clean things up a little.

In this change, I introduce a new `snapshot(spec:name:arguments:congifuration:)` method and called it in every single test method.

```swift
func testEdgecasesRename() throws {
    try snapshot(
        spec: .edgecases,
        name: "edgecases-rename",
        arguments: [
            "--package", "edgecases-rename"
        ],
        configuration: """
        {
            "rename": {
                "properties": {
                    "ContainerA.Child.Child.renameMe": "onlyItRenamed"
                },
                "entities": {
                    "ApiResponse": "APIResponse",
                    "Status": "State"
                }
            }
        }
        """
    )
}
```

This method then internally handles the `--output` path and adds a temporary workaround to account for the inconsistencies between `--package` and `--module`.

Additionally, this method works to separate the concept of a 'name' and 'package'. Currently, every generated snapshot has a different package name because package name == directory name. 

Moving forward, we'll also break that concept so that name == test name and package name == whatever you provide (it doesn't really matter). By doing this, we can use `#function` and it'll make things simpler. I'll do that in a separate change though.

I also renamed `GenerateBaseTests` to `GenerateTestCase` to better distinguish that it's not tests but in fact an `XCTestCase` subclass/base class to be used by Generate related tests.