### PR TITLE
Automatically update AllPackages bundle when regenerating snapshots

### DIFF
--- a/Tests/CreateAPITests/Compliling/PackageCompiler.swift
+++ b/Tests/CreateAPITests/Compliling/PackageCompiler.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+
+final class PackageCompiler: NSObject {
+    static let shared = PackageCompiler()
+
+    private var dependencies: [PackageManifest.Dependency]
+    private var shouldUpdateAllPackages: Bool
+
+    override init() {
+        self.dependencies = []
+        self.shouldUpdateAllPackages = true
+        super.init()
+
+        // Observe the test run to know when all packages have been added
+        #if os(macOS)
+        XCTestObservationCenter.shared.addTestObserver(self)
+        #endif
+    }
+
+    /// Tracks the package at the given location to be included in the AllPackages package after finishing the test run.
+    /// This allows for the generated packages/snapshots to be compiled by CI.
+    func addPackage(at packageURL: URL, name: String, supportsLinux: Bool) {
+        dependencies.append(
+            .init(packageURL: packageURL, name: name, supportsLinux: supportsLinux)
+        )
+    }
+
+    /// Generates the Package.swift file and writes it to **Tests/Support/AllPackages/**
+    private func writeManifestIfNeeded() {
+        guard shouldUpdateAllPackages, !dependencies.isEmpty else { return }
+
+        do {
+            let manifest = PackageManifest(dependencies: dependencies)
+            try manifest.write(to: manifestURL)
+        } catch {
+            fatalError("Failed to generate AllPackages manifest: \(error)")
+        }
+    }
+
+    /// The location of the manifest url
+    private var manifestURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .appendingPathComponent("..")
+            .appendingPathComponent("..")
+            .appendingPathComponent("..")
+            .appendingPathComponent("Support")
+            .appendingPathComponent("AllPackages")
+            .appendingPathComponent("Package.swift")
+            .resolvingSymlinksInPath()
+    }
+}
+
+// MARK: - XCTestObservation
+#if os(macOS)
+extension PackageCompiler: XCTestObservation {
+    func testSuite(_ testSuite: XCTestSuite, didRecord issue: XCTIssue) {
+        shouldUpdateAllPackages = false // don't update if a test failed
+    }
+
+    func testBundleDidFinish(_ testBundle: Bundle) {
+        writeManifestIfNeeded()
+    }
+}
+#endif
+
+// MARK: - Generation

--- a/Tests/CreateAPITests/Compliling/PackageManifest.swift
+++ b/Tests/CreateAPITests/Compliling/PackageManifest.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+struct PackageManifest {
+    struct Dependency: Equatable {
+        let packageURL: URL
+        let name: String
+        let supportsLinux: Bool
+    }
+
+    let dependencies: [Dependency]
+
+    func write(to fileURL: URL) throws {
+        let dependencies = dependencies.sorted()
+        let packageURL = fileURL.deletingLastPathComponent()
+
+        let packageDependencies = dependencies
+            .map { dependencyItem(for: $0, relativeTo: packageURL).asArrayItem(indentation: 8) }
+            .joined(separator: "\n")
+            .removingLast() // remove the trailing comma
+
+        let targetDependencies = dependencies
+            .map { targetDependencyItem(for: $0).asArrayItem(indentation: 16) }
+            .joined(separator: "\n")
+            .removingLast() // remove the trailing comma
+
+        let contents = packageManifestTemplate
+            .replacingOccurrences(of: "{{PACKAGE_DEPENDENCIES}}", with: packageDependencies)
+            .replacingOccurrences(of: "{{TARGET_DEPENDENCIES}}", with: targetDependencies)
+
+        try contents.write(to: fileURL, atomically: false, encoding: .utf8)
+    }
+
+    private func dependencyItem(for dependency: Dependency, relativeTo packageURL: URL) -> String {
+        // .package(path: "../Snapshots/petstore-disable-init-with-coder")
+        let path = dependency.packageURL.relativePath(to: packageURL)
+        return ".package(path: \(path.inDoubleQuotes))"
+    }
+
+    private func targetDependencyItem(for dependency: Dependency) -> String {
+        if dependency.supportsLinux {
+            // "petstore-custom-imports"
+            return dependency.name.inDoubleQuotes
+        } else {
+            // .byName(name: "petstore-custom-imports", condition: .when(platforms: [.macOS]))
+            return ".byName(name: \(dependency.name.inDoubleQuotes), condition: .when(platforms: [.macOS]))"
+        }
+    }
+}
+
+extension PackageManifest.Dependency: Comparable {
+    static func < (lhs: PackageManifest.Dependency, rhs: PackageManifest.Dependency) -> Bool {
+        lhs.packageURL.absoluteString.caseInsensitiveCompare(rhs.packageURL.absoluteString) == .orderedAscending
+    }
+}
+
+private extension String {
+    var inDoubleQuotes: String {
+        "\"\(self)\""
+    }
+
+    func asArrayItem(indentation: Int) -> String {
+        String(repeating: " ", count: indentation) + self + ","
+    }
+
+    func removingLast() -> String {
+        var string = self
+        string.removeLast()
+        return string
+    }
+}
+
+private extension URL {
+    /// Returns the relative path between the receiver and a given url
+    ///
+    /// ```swift
+    /// let base = URL(fileURLWithPath: "/a/b/c/d")
+    /// let other = URL(fileURLWithPath: "/a/b/c/z/y/x/w")
+    /// other.relativePath(to: base) // "../z/y/x/w"
+    /// ```
+    func relativePath(to start: URL) -> String {
+        var startComponents = start.pathComponents
+        var destComponents = self.pathComponents
+
+        while let s = startComponents.first, let d = destComponents.first, s == d {
+            startComponents.removeFirst()
+            destComponents.removeFirst()
+        }
+
+        let ups = Array(repeating: "..", count: startComponents.count)
+        var final = ups + destComponents
+
+        if final.isEmpty { final = ["."] }
+
+        return final.joined(separator: "/")
+    }
+}
+
+private let packageManifestTemplate = """
+ // swift-tools-version: 5.5
+ // The swift-tools-version declares the minimum version of Swift required to build this package.
+
+ // A test helper that allows us to compile all generated packages quickly and easily
+
+ import PackageDescription
+
+ let package = Package(
+     name: "AllPackages",
+     platforms: [
+         .macOS(.v10_15)
+     ],
+     products: [
+         .library(name: "AllPackages", targets: ["AllPackages"])
+     ],
+     dependencies: [
+ {{PACKAGE_DEPENDENCIES}}
+     ],
+     targets: [
+         .target(
+             name: "AllPackages",
+             dependencies: [
+ {{TARGET_DEPENDENCIES}}
+             ],
+             path: "Sources"
+         )
+     ]
+ )
+
+ """

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -60,6 +60,7 @@ final class GenerateOptionsTests: GenerateTestCase {
         try snapshot(
             spec: .petstore,
             name: "petstore-custom-imports",
+            testCompilationOnLinux: false, // custom imports aren't available there.
             arguments: [
                 "--package", "petstore-custom-imports"
             ],

--- a/Tests/CreateAPITests/GenerateTestCase.swift
+++ b/Tests/CreateAPITests/GenerateTestCase.swift
@@ -21,6 +21,7 @@ class GenerateTestCase: XCTestCase {
     func snapshot(
         spec: SpecFixture,
         name: String, // TODO: Default to #function
+        testCompilationOnLinux: Bool = true,
         arguments: [String] = [],
         configuration: String? = nil
     ) throws {
@@ -44,7 +45,7 @@ class GenerateTestCase: XCTestCase {
 
         // If we snapshotted a package in record mode then include in compiler tests
         if let package = command.package, case .record = snapshotter.behavior {
-            compiler.addPackage(at: snapshotURL, name: package, supportsLinux: true)
+            compiler.addPackage(at: snapshotURL, name: package, supportsLinux: testCompilationOnLinux)
         }
     }
 

--- a/Tests/CreateAPITests/Snapshotting/Snapshotter.swift
+++ b/Tests/CreateAPITests/Snapshotting/Snapshotter.swift
@@ -20,7 +20,7 @@ class Snapshotter {
     }
 
     /// Processes a snapshot at the given path by either asserting a match against a stored snapshot, or rewriting it.
-    func processSnapshot(at generatedURL: URL, against name: String) throws {
+    func processSnapshot(at generatedURL: URL, against name: String) throws -> URL {
         let snapshotURL = snapshotLocation(for: name)
 
         switch behavior {
@@ -33,6 +33,8 @@ class Snapshotter {
             try fileManager.copyItem(at: generatedURL, to: snapshotURL)
             recordedSnapshots.append(snapshotURL)
         }
+
+        return snapshotURL
     }
 
     /// The location of a generated snapshot stored on disk

--- a/Tests/Support/AllPackages/Package.swift
+++ b/Tests/Support/AllPackages/Package.swift
@@ -2,7 +2,6 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // A test helper that allows us to compile all generated packages quickly and easily
-// TODO: We should probably generate this file on-demand for the tests rather than having to edit it each time.
 
 import PackageDescription
 
@@ -45,11 +44,11 @@ let package = Package(
         .package(path: "../Snapshots/petstore-filename-template"),
         .package(path: "../Snapshots/petstore-generate-classes"),
         .package(path: "../Snapshots/petstore-identifiable"),
+        .package(path: "../Snapshots/petstore-merge-sources"),
         .package(path: "../Snapshots/petstore-only-schemas"),
         .package(path: "../Snapshots/petstore-single-threaded"),
         .package(path: "../Snapshots/petstore-some-entities-as-classes"),
         .package(path: "../Snapshots/petstore-some-entities-as-structs"),
-        .package(path: "../Snapshots/petstore-merge-sources"),
         .package(path: "../Snapshots/strip-parent-name-nested-objects-default"),
         .package(path: "../Snapshots/strip-parent-name-nested-objects-enabled"),
         .package(path: "../Snapshots/test-query-parameters")
@@ -77,7 +76,7 @@ let package = Package(
                 "petstore-change-entityname",
                 "petstore-change-namespace-when-operations-style",
                 "petstore-change-namespace-when-rest-style",
-                .byName(name: "petstore-custom-imports", condition: .when(platforms: [.iOS, .macOS])),
+                .byName(name: "petstore-custom-imports", condition: .when(platforms: [.macOS])),
                 "petstore-default",
                 "petstore-disable-comments",
                 "petstore-disable-init-with-coder",
@@ -88,11 +87,11 @@ let package = Package(
                 "petstore-filename-template",
                 "petstore-generate-classes",
                 "petstore-identifiable",
+                "petstore-merge-sources",
                 "petstore-only-schemas",
                 "petstore-single-threaded",
                 "petstore-some-entities-as-classes",
                 "petstore-some-entities-as-structs",
-                "petstore-merge-sources",
                 "strip-parent-name-nested-objects-default",
                 "strip-parent-name-nested-objects-enabled",
                 "test-query-parameters"


### PR DESCRIPTION
When we recreate the generator snapshots, if we add a new package we usually have to manually update **Tests/CreateAPITests/AllPackages/Package.swift** so that CI will try and build the package when we create Pull Requests. This was a pain to keep on top of. 

In this change, I update the tests so that they record all of the generated packages and upon completion of the tests, they update the **Package.swift** file. 

It's a little rough and ready, but I didn't want to spend a lot of time refactoring this area although I think that we probably could do. Any suggestions for improvements are welcome.

cc @LePips 