### PR TITLE
Stop printing filepaths when writing output

### DIFF
--- a/Sources/CreateAPI/Output/OutputWriter.swift
+++ b/Sources/CreateAPI/Output/OutputWriter.swift
@@ -29,7 +29,6 @@ class OutputWriter {
             try directoryURL.createDirectoryIfNeeded()
 
             // Write the source to file
-            print("Writing to", subpath)
             try contents.write(to: fileURL)
             writtenPaths.insert(subpath)
         }


### PR DESCRIPTION
In #117 I accidentally left a print statement whenever we write a file to disk. 