### PR TITLE
Raise error if `--config` file location does not exist or is not valid

### DIFF
--- a/Sources/CreateAPI/Helpers/ConfigFileLocation.swift
+++ b/Sources/CreateAPI/Helpers/ConfigFileLocation.swift
@@ -1,0 +1,56 @@
+import ArgumentParser
+import Foundation
+
+/// A wrapper for reading the location of the configuration file and a utility for providing the resolved `fileURL`.
+struct ConfigFileLocation {
+    var userDefinedPath: String?
+    let defaultPath = ".create-api.yaml"
+
+    /// Returns the resolved fileURL, which can be one of the following:
+    ///
+    /// 1. A path to the user defined configuration file.
+    /// 2. A path to the configuration at the default location **if** the file exists.
+    /// 3. `nil` if a file did not exist at the default location.
+    ///
+    /// - throws: `GeneratorError` if the file does not exist at the user defined location.
+    var fileURL: URL? {
+        get throws {
+            let isUserDefined = userDefinedPath != nil
+            let fileURL = URL(filePath: userDefinedPath ?? defaultPath)
+
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: fileURL.path) {
+                return fileURL
+            }
+
+            if isUserDefined {
+                throw GeneratorError("The configuration file at \(fileURL.path) does not exist.")
+            } else {
+                return nil // Indicates that no configuration was provided, use the default.
+            }
+        }
+    }
+
+    init() {
+        self.userDefinedPath = nil
+    }
+}
+
+// MARK: - ExpressibleByArgument
+extension ConfigFileLocation: ExpressibleByArgument {
+    init?(argument: String) {
+        self.userDefinedPath = argument
+    }
+
+    var defaultValueDescription: String {
+        defaultPath
+    }
+
+    static var allValueStrings: [String] {
+        []
+    }
+
+    static var defaultCompletionKind: CompletionKind {
+        .file(extensions: ["yaml", "yml", "json"])
+    }
+}

--- a/Tests/CreateAPITests/GenerateArgumentTests.swift
+++ b/Tests/CreateAPITests/GenerateArgumentTests.swift
@@ -1,0 +1,57 @@
+@testable import create_api
+import XCTest
+
+final class GenerateArgumentTests: GenerateTestCase {
+    func testConfig_defaultFileDoesNotExist() throws {
+        // Given no default configuration file exists in the default location
+        try? FileManager.default.removeItem(at: temp.url.appending(path: ".create-api.yml"))
+
+        // When `--config` is not specified in the options
+        let arguments: [String] = [
+            "--package", "Package",
+            "--output", temp.url.path,
+            SpecFixture.edgecases.path
+        ]
+
+        // Then the generator will not throw an error if the file doesn't exist
+        XCTAssertNoThrow(try generate(arguments))
+    }
+
+    func testConfig_userDefinedDefaultLocationDoesNotExist() throws {
+        // Given no default configuration file exists in the default location
+        try? FileManager.default.removeItem(at: temp.url.appending(path: ".create-api.yml"))
+
+        // When `--config` is not specified as the same location that is the default
+        let arguments: [String] = [
+            "--config", ".create-api.yaml",
+            "--package", "Package",
+            "--output", temp.url.path,
+            SpecFixture.edgecases.path
+        ]
+
+        // Then the generator will throw an error because the specified file does not exist
+        XCTAssertThrowsError(try generate(arguments)) { error in
+            // Error contains absolute path which is not stable when testing
+            XCTAssertTrue(error.localizedDescription.hasSuffix(".create-api.yaml does not exist."))
+        }
+    }
+
+    func testConfig_userDefinedCustomLocationDoesNotExist() throws {
+        // Given no default configuration file exists in the user-defined location
+        try? FileManager.default.removeItem(at: temp.url.appending(path: "options.json"))
+
+        // When `--config` is defined as a custom location
+        let arguments: [String] = [
+            "--config", "options.json",
+            "--package", "Package",
+            "--output", temp.url.path,
+            SpecFixture.edgecases.path
+        ]
+
+        // Then the generator will throw an error because the specified file does not exist
+        XCTAssertThrowsError(try generate(arguments)) { error in
+            // Error contains absolute path which is not stable when testing
+            XCTAssertTrue(error.localizedDescription.hasSuffix("options.json does not exist."))
+        }
+    }
+}

--- a/Tests/CreateAPITests/GenerateTestCase.swift
+++ b/Tests/CreateAPITests/GenerateTestCase.swift
@@ -54,14 +54,15 @@ class GenerateTestCase: XCTestCase {
         }
         arguments.append(spec.path)
 
-        // Given the command is parsed
-        let command = try Generate.parse(arguments)
-
-        // When the command is run
-        try command.run()
+        // Run the generator with the given arguments
+        try generate(arguments)
 
         // Then the output should match what was generated
         try compare(expected: name, actual: temp.path(for: name))
+    }
+
+    func generate(_ arguments: [String]) throws {
+        try Generate.parse(arguments).run()
     }
     
     private func config(_ contents: String, ext: String = "json") -> String {


### PR DESCRIPTION
- part of #47 

Prior to this change, if you ran the following:

```bash
$ create-api generate --config wrong/path/to/config.yml schema.json
```

The generator would ignore the fact that **wrong/path/to/config.yml** was an invalid path as long as it had the right extension. Instead, it would just revert to using the default config, which might leave the user confused as to why their options aren't being applied. 

It most likely did this because the default value was always set to **.create-api.yaml** and we don't necessarily expect this file to always exist, and we wouldn't want to error if it didn't since the user didn't explicitly define it. 

It was a bit hard to check this in the `Generate` command with the `config` alone since it's just a `String` and Swift Arguments Parser doesn't give you a way to differentiate between default values and user defined values out of the box. 

For example, if you specified `--config .create-api.yaml` (the default value) explicitly, we'd still want to error if that file didn't exist. 

To fix this, I opted to introduce a new `ConfigFileLocation` type that conforms to `ExpressibleByArgument`. By doing this, I am able to differentiate between the default value, and a user defiled value passed into `init?(argument:)`. I then added an extension to expose the resolved `fileURL` which will throw an error if the file doesn't exist like we expect. 

I also added some test coverage to make sure errors are thrown (not something we typically do)