### PR TITLE
[BREAKING] Generate `--package` directly into `--output`

### DIFF
--- a/Sources/CreateAPI/Output/Output.swift
+++ b/Sources/CreateAPI/Output/Output.swift
@@ -16,11 +16,9 @@ struct Output {
         // Write the Package.swift manifest file, or figure out the writer for source files
         let sourcesWriter: OutputWriter
         if let package = package {
-            let packageWriter = rootWriter.writer(in: package.name)
             // TODO: Use `write(file:header:template:options:)` to match indentation for Package.swift?
-            try packageWriter.write(package.manifest.contents, to: "\(package.manifest.name).swift")
-
-            sourcesWriter = packageWriter.writer(in: "Sources")
+            try rootWriter.write(package.manifest.contents, to: "\(package.manifest.name).swift")
+            sourcesWriter = rootWriter.writer(in: "Sources")
         } else {
             sourcesWriter = rootWriter
         }

--- a/Tests/CreateAPITests/GenerateTestCase.swift
+++ b/Tests/CreateAPITests/GenerateTestCase.swift
@@ -40,11 +40,9 @@ class GenerateTestCase: XCTestCase {
         arguments: [String] = [],
         configuration: String? = nil
     ) throws {
-        // TODO: Remove this after https://github.com/CreateAPI/CreateAPI/issues/88
-        var output = temp.url.path
-        if !arguments.contains("--package") {
-            output.append("/" + name)
-        }
+        let output = temp.url
+            .appendingPathComponent("Output")
+            .path
 
         // Append the output, config and spec to the arguments passed
         var arguments = arguments
@@ -58,7 +56,7 @@ class GenerateTestCase: XCTestCase {
         try generate(arguments)
 
         // Then the output should match what was generated
-        try compare(expected: name, actual: temp.path(for: name))
+        try compare(expected: name, actual: output)
     }
 
     func generate(_ arguments: [String]) throws {


### PR DESCRIPTION
- part of #88 

When generating, CreateAPI will nest the generated **Package.swift** (and other files) in side a directory within the output dir. This is inconsistent with how `--module` generation works and results in incorrect usage of the `--output` flag since its expected that the output is an empty directory (for `--clean` to not mistakenly delete non-generated sources).

This change aligns the behaviour between `--package` and `--module` so that all generated contents are located in the root of the `--output` directory. 

There are changes to the snapshot tests here since I'm able to just revert the workaround that we used in the first place. 