### PR TITLE
Validate that clean isn't going to delete spec or config file

### DIFF
--- a/Sources/CreateAPI/Generate.swift
+++ b/Sources/CreateAPI/Generate.swift
@@ -110,6 +110,13 @@ struct Generate: ParsableCommand {
     }
 
     private func validateOptions(options: GenerateOptions) throws {
+        let outputPath = URL(fileURLWithPath: output).resolvingSymlinksInPath().path
+        if clean, let configPath = try config.fileURL?.resolvingSymlinksInPath().path, configPath.hasPrefix(outputPath) {
+            throw GeneratorError("Trying to use --clean with an --output that will delete the config file")
+        }
+        if clean, URL(fileURLWithPath: input).resolvingSymlinksInPath().path.hasPrefix(outputPath) {
+            throw GeneratorError("Trying to use --clean with an --output that will delete the input spec")
+        }
         if module != nil && package != nil {
             throw GeneratorError("`module` and `package` parameters are mutually exclusive")
         }

--- a/Sources/CreateAPI/Generate.swift
+++ b/Sources/CreateAPI/Generate.swift
@@ -112,10 +112,10 @@ struct Generate: ParsableCommand {
     private func validateOptions(options: GenerateOptions) throws {
         let outputPath = URL(fileURLWithPath: output).resolvingSymlinksInPath().path
         if clean, let configPath = try config.fileURL?.resolvingSymlinksInPath().path, configPath.hasPrefix(outputPath) {
-            throw GeneratorError("Trying to use --clean with an --output that will delete the config file")
+            throw GeneratorError("Unable to clean because your config file is in the output directory")
         }
         if clean, URL(fileURLWithPath: input).resolvingSymlinksInPath().path.hasPrefix(outputPath) {
-            throw GeneratorError("Trying to use --clean with an --output that will delete the input spec")
+            throw GeneratorError("Unable to clean because your input spec is in the output directory")
         }
         if module != nil && package != nil {
             throw GeneratorError("`module` and `package` parameters are mutually exclusive")

--- a/Tests/CreateAPITests/GenerateArgumentTests.swift
+++ b/Tests/CreateAPITests/GenerateArgumentTests.swift
@@ -54,4 +54,63 @@ final class GenerateArgumentTests: GenerateTestCase {
             XCTAssertTrue(error.localizedDescription.hasSuffix("options.json does not exist."))
         }
     }
+
+    func testClean() throws {
+        // Given old source files exist in the output directory
+        let oldFileURL = temp.url.appendingPathComponent("Old.swift")
+        try "".write(to: oldFileURL)
+
+        // When the arguments result in cleaning the output
+        let arguments: [String] = [
+            "--clean",
+            "--package", "Package",
+            "--output", temp.url.path,
+            SpecFixture.edgecases.path
+        ]
+
+        // Then the generator will succeed and the old source file will have been removed
+        XCTAssertNoThrow(try generate(arguments))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldFileURL.path))
+    }
+
+    func testClean_notAllowedWhenConfigIsInTheOutput() throws {
+        // Given `--config` file exists in the output directory
+        let configURL = temp.url.appendingPathComponent(".create-api.yml")
+        try "{}".write(to: configURL)
+
+        // When the arguments result in trying to clean the config file
+        let arguments: [String] = [
+            "--clean",
+            "--config", configURL.path,
+            "--package", "Package",
+            "--output", temp.url.path,
+            SpecFixture.edgecases.path
+        ]
+
+        // Then the generator will throw an error to protect the config
+        XCTAssertThrowsError(try generate(arguments)) { error in
+            XCTAssertEqual(error.localizedDescription, "Trying to use --clean with an --output that will delete the config file")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: configURL.path))
+    }
+
+    func testClean_notAllowedWhenSpecIsInTheOutput() throws {
+        // Given the input spec file exists in the output directory
+        let specURL = temp.url.appendingPathComponent("schema.json")
+        try FileManager.default.copyItem(atPath: SpecFixture.edgecases.path, toPath: specURL.path)
+
+        // When the arguments result in trying to clean the spec file
+        let arguments: [String] = [
+            "--clean",
+            "--package", "Package",
+            "--output", temp.url.path,
+            specURL.path
+        ]
+
+        // Then the generator will throw an error because the spec cannot be deleted
+        XCTAssertThrowsError(try generate(arguments)) { error in
+            XCTAssertEqual(error.localizedDescription, "Trying to use --clean with an --output that will delete the input spec")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: specURL.path))
+    }
 }

--- a/Tests/CreateAPITests/GenerateArgumentTests.swift
+++ b/Tests/CreateAPITests/GenerateArgumentTests.swift
@@ -89,7 +89,7 @@ final class GenerateArgumentTests: GenerateTestCase {
 
         // Then the generator will throw an error to protect the config
         XCTAssertThrowsError(try generate(arguments)) { error in
-            XCTAssertEqual(error.localizedDescription, "Trying to use --clean with an --output that will delete the config file")
+            XCTAssertEqual(error.localizedDescription, "Unable to clean because your config file is in the output directory")
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: configURL.path))
     }
@@ -109,7 +109,7 @@ final class GenerateArgumentTests: GenerateTestCase {
 
         // Then the generator will throw an error because the spec cannot be deleted
         XCTAssertThrowsError(try generate(arguments)) { error in
-            XCTAssertEqual(error.localizedDescription, "Trying to use --clean with an --output that will delete the input spec")
+            XCTAssertEqual(error.localizedDescription, "Unable to clean because your input spec is in the output directory")
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: specURL.path))
     }


### PR DESCRIPTION
- closes #88 

Prior to this change, if you ran the generator like this:

```bash
$ create-api generate --config ".create-api.yml" --package "Foo" --output "./" "schema.json" --clean
```

Then you would find that **.create-api.yml** and **schema.json** along with any other files within **./** end up being deleted.

This is not ideal, but its mostly a problem because of how `--package` **use** to work as it nested the output meaning that people were more likely to use **./** as their output directory. We've since solved that inconsistency however and now it's expected that people will use a separate output directory. 

If they don't however, and try using `--clean`, this PR will now cause the generator to error instead. 