### PR TITLE
Change `--output` directory to ./CreateAPI

### DIFF
--- a/Sources/CreateAPI/Generate.swift
+++ b/Sources/CreateAPI/Generate.swift
@@ -15,8 +15,8 @@ struct Generate: ParsableCommand {
     @Argument(help: "The OpenAPI spec input file in either JSON or YAML format")
     var input: String
 
-    @Option(help: "The output folder")
-    var output = "./.create-api/"
+    @Option(help: "The directory where generated outputs are written")
+    var output = "CreateAPI"
 
     @Option(help: ArgumentHelp("The path to generator configuration.", discussion: """
         If not provided, the command will automatically try using .create-api.yaml \


### PR DESCRIPTION
#101

Prior to this change, if you didn't specify the `--output` directory then your generated sources would be written into the hidden **./.create-api/** directory. 

This is probably a bit confusing and also the format (lower-hyphen-case) doesn't really match styles of typical Swift/Xcode projects.

In this change, I adjust the default to **CreateAPI**, which seems a little more fitting.