### PR TITLE
`rename.properties` respects schema names

### DIFF
--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -759,14 +759,20 @@ Options used to configure detailed renaming rules for all aspects of the generat
 **Type:** [String: String]<br />
 **Default:** `[:]`
 
-Rename rules for properties specific to a given type, or all properties with a matching name.
+Rename schema properties prior to processing. Rules can apply to all properties or to
+properties of a specific entity.
+
+<details>
+<summary>Examples</summary>
 
 ```yaml
 rename:
   properties:
-    name: firstName # renames any property called 'name' to 'firstName'
-    SimpleUser.name: firstName # renames only the 'name' property on the 'SimpleUser' entity
+    favorite_food: food # renames any schema property called 'favorite_food` to food
+    User.first_name: name # renames only the 'first_name` schema property on the `User` entity
 ```
+
+</details>
 
 <br/>
 

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -490,14 +490,20 @@ public struct ConfigOptions: ParsableConfiguration {
     public struct Rename: ParsableConfiguration {
         public init() { }
 
-        /// Rename rules for properties specific to a given type, or all properties with a matching name.
+        /// Rename schema properties prior to processing. Rules can apply to all properties or to
+        /// properties of a specific entity.
+        ///
+        /// <details>
+        /// <summary>Examples</summary>
         ///
         /// ```yaml
         /// rename:
         ///   properties:
-        ///     name: firstName # renames any property called 'name' to 'firstName'
-        ///     SimpleUser.name: firstName # renames only the 'name' property on the 'SimpleUser' entity
+        ///     favorite_food: food # renames any schema property called 'favorite_food` to food
+        ///     User.first_name: name # renames only the 'first_name` schema property on the `User` entity
         /// ```
+        ///
+        /// </details>
         @Option public var properties: [String: String] = [:]
 
         /// Rename query parameters

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -387,7 +387,7 @@ final class GenerateOptionsTests: GenerateTestCase {
             {
                 "rename": {
                     "properties": {
-                        "ContainerA.Child.Child.renameMe": "onlyItRenamed"
+                        "ContainerA.Child.Child.rename-me": "onlyItRenamed"
                     },
                     "entities": {
                         "ApiResponse": "APIResponse",

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -532,7 +532,7 @@ final class GenerateOptionsTests: GenerateTestCase {
                 - Store.pets
             rename:
                 properties:
-                    Pet.id: notID
+                    Pet.id: not_id
                     Pet.name: id
             """
         )

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -341,7 +341,7 @@ final class GenerateOptionsTests: GenerateTestCase {
                     id: identifier
                     Category.name: title
                     Pet.status: state
-                    complete: isDone
+                    complete: done
             """
         )
     }


### PR DESCRIPTION
- Closes https://github.com/CreateAPI/CreateAPI/issues/112

Renames property names prior to processing, meaning that they will respect the schema name instead of the final Swift name. Updates the edge case test for proper schema renaming and some other tests that renamed _to_ a Swifty name.