### PR TITLE
Change default behaviour of `isInliningPropertiesFromReferencedSchemas` (now `inlineReferencedSchemas`)

### DIFF
--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -559,7 +559,58 @@ If set to `true`, uses the `default` value from the schema for the generated pro
 **Type:** Bool<br />
 **Default:** `true`
 
-For `allOf` inline properties from references
+Controls the behaviour when generating entities from nested `allOf` schemas.
+
+<details>
+<summary>Examples</summary>
+
+With the following schema:
+
+```yaml
+components:
+  schemas:
+    Animal:
+      properties:
+        numberOfLegs:
+          type: integer
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Animal'
+      - type: object
+        properties:
+          goodBoy:
+            type: boolean
+```
+
+When this property is set to `true` (the default):
+
+```swift
+struct Animal: Codable {
+    var numberOfLegs: Int
+}
+
+struct Dog: Codable {
+    var numberOfLegs: Int
+    var isGoodBoy: Bool
+}
+```
+
+However setting this property to `false` results results in the following:
+
+```swift
+struct Animal: Codable {
+    var numberOfLegs: Int
+}
+
+struct Dog: Codable {
+    var animal: Animal
+    var isGoodBoy: Bool
+
+    // ...
+}
+```
+
+</details>
 
 <br/>
 

--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -557,7 +557,7 @@ If set to `true`, uses the `default` value from the schema for the generated pro
 ## entities.inlineReferencedSchemas
 
 **Type:** Bool<br />
-**Default:** `false`
+**Default:** `true`
 
 For `allOf` inline properties from references
 

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -364,7 +364,7 @@ public struct ConfigOptions: ParsableConfiguration {
 
         // TODO: Improve this documentation
         /// For `allOf` inline properties from references
-        @Option public var inlineReferencedSchemas: Bool = false
+        @Option public var inlineReferencedSchemas: Bool = true
 
         /// Strips the parent name of enum cases within objects that are `oneOf` / `allOf` / `anyOf` of nested references
         @Option public var stripParentNameInNestedObjects: Bool = false

--- a/Sources/CreateOptions/ConfigOptions.swift
+++ b/Sources/CreateOptions/ConfigOptions.swift
@@ -362,8 +362,58 @@ public struct ConfigOptions: ParsableConfiguration {
         /// If set to `true`, uses the `default` value from the schema for the generated property for booleans
         @Option public var includeDefaultValues: Bool = true
 
-        // TODO: Improve this documentation
-        /// For `allOf` inline properties from references
+        /// Controls the behaviour when generating entities from nested `allOf` schemas.
+        ///
+        /// <details>
+        /// <summary>Examples</summary>
+        ///
+        /// With the following schema:
+        ///
+        /// ```yaml
+        /// components:
+        ///   schemas:
+        ///     Animal:
+        ///       properties:
+        ///         numberOfLegs:
+        ///           type: integer
+        ///     Dog:
+        ///       allOf:
+        ///       - $ref: '#/components/schemas/Animal'
+        ///       - type: object
+        ///         properties:
+        ///           goodBoy:
+        ///             type: boolean
+        /// ```
+        ///
+        /// When this property is set to `true` (the default):
+        ///
+        /// ```swift
+        /// struct Animal: Codable {
+        ///     var numberOfLegs: Int
+        /// }
+        ///
+        /// struct Dog: Codable {
+        ///     var numberOfLegs: Int
+        ///     var isGoodBoy: Bool
+        /// }
+        /// ```
+        ///
+        /// However setting this property to `false` results results in the following:
+        ///
+        /// ```swift
+        /// struct Animal: Codable {
+        ///     var numberOfLegs: Int
+        /// }
+        ///
+        /// struct Dog: Codable {
+        ///     var animal: Animal
+        ///     var isGoodBoy: Bool
+        ///
+        ///     // ...
+        /// }
+        /// ```
+        ///
+        /// </details>
         @Option public var inlineReferencedSchemas: Bool = true
 
         /// Strips the parent name of enum cases within objects that are `oneOf` / `allOf` / `anyOf` of nested references

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -50,6 +50,8 @@ final class GenerateTests: GenerateTestCase {
                 accepted: "Void"
               overriddenBodyTypes:
                 application/octocat-stream: String
+            entities:
+              inlineReferencedSchemas: false
             rename:
               enumCases:
                 reactions-+1: "reactionsPlusOne"

--- a/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 struct Cat: Codable {
-    var animal: Animal
+    var className: String
+    var color: String?
     var isDeclawed: Bool?
 
-    init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 struct Dog: Codable {
-    var animal: Animal
+    var className: String
+    var color: String?
     var breed: Breed?
     var image: Image?
 
@@ -15,22 +16,25 @@ struct Dog: Codable {
         case small = "Small"
     }
 
-    init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-default/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-default/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-default/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-default/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Entities/Dog.swift
@@ -5,26 +5,30 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: String?
     public var image: Image?
 
-    public init(animal: Animal, breed: String? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: String? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(String.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-  public var animal: Animal
+  public var className: String
+  public var color: String?
   public var isDeclawed: Bool?
 
-  public init(animal: Animal, isDeclawed: Bool? = nil) {
-    self.animal = animal
+  public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+    self.className = className
+    self.color = color
     self.isDeclawed = isDeclawed
   }
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: StringCodingKey.self)
-    self.animal = try Animal(from: decoder)
+    self.className = try values.decode(String.self, forKey: "className")
+    self.color = try values.decodeIfPresent(String.self, forKey: "color")
     self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
   }
 
   public func encode(to encoder: Encoder) throws {
     var values = encoder.container(keyedBy: StringCodingKey.self)
-    try values.encode(animal, forKey: "animal")
+    try values.encode(className, forKey: "className")
+    try values.encodeIfPresent(color, forKey: "color")
     try values.encodeIfPresent(isDeclawed, forKey: "declawed")
   }
 }

--- a/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-  public var animal: Animal
+  public var className: String
+  public var color: String?
   public var breed: Breed?
   public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
     case small = "Small"
   }
 
-  public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-    self.animal = animal
+  public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+    self.className = className
+    self.color = color
     self.breed = breed
     self.image = image
   }
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: StringCodingKey.self)
-    self.animal = try Animal(from: decoder)
+    self.className = try values.decode(String.self, forKey: "className")
+    self.color = try values.decodeIfPresent(String.self, forKey: "color")
     self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
     self.image = try values.decodeIfPresent(Image.self, forKey: "image")
   }
 
   public func encode(to encoder: Encoder) throws {
     var values = encoder.container(keyedBy: StringCodingKey.self)
-    try values.encode(animal, forKey: "animal")
+    try values.encode(className, forKey: "className")
+    try values.encodeIfPresent(color, forKey: "color")
     try values.encodeIfPresent(breed, forKey: "breed")
     try values.encodeIfPresent(image, forKey: "image")
   }

--- a/Tests/Support/Snapshots/edgecases-int32-int64/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-int32-int64/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-int32-int64/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-int32-int64/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-rename/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-rename/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-rename/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-rename/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }

--- a/Tests/Support/Snapshots/edgecases-tabs/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-tabs/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-	public var animal: Animal
+	public var className: String
+	public var color: String?
 	public var isDeclawed: Bool?
 
-	public init(animal: Animal, isDeclawed: Bool? = nil) {
-		self.animal = animal
+	public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+		self.className = className
+		self.color = color
 		self.isDeclawed = isDeclawed
 	}
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
-		self.animal = try Animal(from: decoder)
+		self.className = try values.decode(String.self, forKey: "className")
+		self.color = try values.decodeIfPresent(String.self, forKey: "color")
 		self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
 	}
 
 	public func encode(to encoder: Encoder) throws {
 		var values = encoder.container(keyedBy: StringCodingKey.self)
-		try values.encode(animal, forKey: "animal")
+		try values.encode(className, forKey: "className")
+		try values.encodeIfPresent(color, forKey: "color")
 		try values.encodeIfPresent(isDeclawed, forKey: "declawed")
 	}
 }

--- a/Tests/Support/Snapshots/edgecases-tabs/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-tabs/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-	public var animal: Animal
+	public var className: String
+	public var color: String?
 	public var breed: Breed?
 	public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
 		case small = "Small"
 	}
 
-	public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-		self.animal = animal
+	public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+		self.className = className
+		self.color = color
 		self.breed = breed
 		self.image = image
 	}
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
-		self.animal = try Animal(from: decoder)
+		self.className = try values.decode(String.self, forKey: "className")
+		self.color = try values.decodeIfPresent(String.self, forKey: "color")
 		self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
 		self.image = try values.decodeIfPresent(Image.self, forKey: "image")
 	}
 
 	public func encode(to encoder: Encoder) throws {
 		var values = encoder.container(keyedBy: StringCodingKey.self)
-		try values.encode(animal, forKey: "animal")
+		try values.encode(className, forKey: "className")
+		try values.encodeIfPresent(color, forKey: "color")
 		try values.encodeIfPresent(breed, forKey: "breed")
 		try values.encodeIfPresent(image, forKey: "image")
 	}

--- a/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Entities/Cat.swift
+++ b/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Entities/Cat.swift
@@ -5,23 +5,27 @@ import Foundation
 import NaiveDate
 
 public struct Cat: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var isDeclawed: Bool?
 
-    public init(animal: Animal, isDeclawed: Bool? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, isDeclawed: Bool? = nil) {
+        self.className = className
+        self.color = color
         self.isDeclawed = isDeclawed
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.isDeclawed = try values.decodeIfPresent(Bool.self, forKey: "declawed")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(isDeclawed, forKey: "declawed")
     }
 }

--- a/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Entities/Dog.swift
+++ b/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Entities/Dog.swift
@@ -5,7 +5,8 @@ import Foundation
 import NaiveDate
 
 public struct Dog: Codable {
-    public var animal: Animal
+    public var className: String
+    public var color: String?
     public var breed: Breed?
     public var image: Image?
 
@@ -15,22 +16,25 @@ public struct Dog: Codable {
         case small = "Small"
     }
 
-    public init(animal: Animal, breed: Breed? = nil, image: Image? = nil) {
-        self.animal = animal
+    public init(className: String, color: String? = nil, breed: Breed? = nil, image: Image? = nil) {
+        self.className = className
+        self.color = color
         self.breed = breed
         self.image = image
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.animal = try Animal(from: decoder)
+        self.className = try values.decode(String.self, forKey: "className")
+        self.color = try values.decodeIfPresent(String.self, forKey: "color")
         self.breed = try values.decodeIfPresent(Breed.self, forKey: "breed")
         self.image = try values.decodeIfPresent(Image.self, forKey: "image")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(animal, forKey: "animal")
+        try values.encode(className, forKey: "className")
+        try values.encodeIfPresent(color, forKey: "color")
         try values.encodeIfPresent(breed, forKey: "breed")
         try values.encodeIfPresent(image, forKey: "image")
     }


### PR DESCRIPTION
# Background 

- Closes #63 

Currently CreateAPI takes one of two approaches when dealing with schemas that reference other types using `allOf`:

1. Nest the referenced entity within
2. Inline the properties from the referenced entity

Until this changes, the former was the default behaviour however this behaviour isn't really inline with what you might expect a generator to do and it results in a strangely formed (but functional) entity. 

In the future, we plan to improve the inlining behaviour by adding other alternatives (i.e protocol composition and maybe even class inheritance) but for now we want to change the default behaviour. 

# Changes

In this PR, I update `isInliningPropertiesFromReferencedSchemas` (now `inlineReferencedSchemas`) so that properties are inlined into the entity by default. 

I also regenerate the snapshots to reflect the change in default behaviour. 