### PR TITLE
Run path generation in parallel when specified

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Paths.swift
+++ b/Sources/CreateAPI/Generator/Generator+Paths.swift
@@ -20,7 +20,7 @@ extension Generator {
         let jobs = makeJobs()
         var generated = [Result<GeneratedFile, Error>?](repeating: nil, count: jobs.count)
         let lock = NSLock()
-        concurrentPerform(on: jobs, parallel: arguments.isVerbose) { index, job in
+        concurrentPerform(on: jobs, parallel: arguments.isParallel) { index, job in
             do {
                 let entry = try makeEntry(for: job)
                 let file = GeneratedFile(name: makeTypeName(job.filename).rawValue, contents: entry)


### PR DESCRIPTION
I noticed that the code to generate paths would only perform parallel generation when `--verbose` was specified. Something that I assume was done during debugging but committed by mistake? 

It's inconsistent with the other implementation so I have instead set this value back to check `arguments.isParallel` instead. The result is that by default, the GitHub spec now generates a bit quicker:

### Before

```
$ swift run create-api generate Tests/Support/Specs/github.yaml --config-option module=OctoKit --measure --clean
...
Generate paths completed (0.852 s)
Generating entities completed (0.402 s)
Write output files completed (0.170 s)
Generation completed (2.892 s)
```

### After

```
$ swift run create-api generate Tests/Support/Specs/github.yaml --config-option module=OctoKit --measure --clean
...
Generate paths completed (0.280 s)
Generating entities completed (0.410 s)
Write output files completed (0.163 s)
Generation completed (2.293 s)
```