### PR TITLE
Support generating enum types as `RawRepresentable` structs

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -15,10 +15,17 @@ extension Generator {
 
     private func render(_ decl: EnumOfStringsDeclaration) -> String {
         let comments = templates.comments(for: decl.metadata, name: decl.name.rawValue)
-        let cases = decl.cases.map {
-            templates.case(name: $0.name, value: $0.key)
-        }.joined(separator: "\n")
-        return comments + templates.enumOfStrings(name: decl.name, contents: cases)
+
+        let content: String
+        if false { // TODO: Switch on the format/style 
+            let constants = decl.cases.map({ templates.rawRepresentableConstant(name: $0.name, value: $0.key) }).joined(separator: "\n")
+            content = templates.rawRepresentable(name: decl.name, contents: constants)
+        } else {
+            let cases = decl.cases.map({ templates.case(name: $0.name, value: $0.key) }).joined(separator: "\n")
+            content = templates.enumOfStrings(name: decl.name, contents: cases)
+        }
+
+        return comments + content
     }
 
     private func render(_ decl: EntityDeclaration) throws -> String {

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -637,7 +637,7 @@ extension Generator {
 
     func makeStringEnum(name: TypeName, info: JSONSchemaContext) throws -> Declaration {
         let values = (info.allowedValues ?? []).map(\.value).compactMap { $0 as? String }
-        guard !values.isEmpty else {
+        guard !values.isEmpty else { // TODO: Relax this rule when rendering as a struct
             throw GeneratorError("Enum \"\(name)\" has no values")
         }
 

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -102,6 +102,25 @@ final class Templates {
         """
     }
 
+    func rawRepresentableConstant(name: String, value: String) -> String {
+        let value = value.isEscapingNeeded ? "#\"\(value)\"#" : "\"\(value)\""
+        return "\(access)static let \(name) = Self(rawValue: \(value))"
+    }
+
+    func rawRepresentable(name: TypeName, type: String = "String", contents: String) -> String {
+        return """
+        \(access)struct \(name): RawRepresentable, Codable {
+            \(access)let rawValue: \(type)
+
+            \(access)init(rawValue: \(type)) {
+                self.rawValue = rawValue
+            }
+
+        \(contents.indented)
+        }
+        """
+    }
+
     // MARK: Query Parameters
 
     func asQuery(properties: [Property]) -> String {


### PR DESCRIPTION
- Closes #130

A common pattern that we are seeing is that there is sometimes a discrepancy on the characteristics of an enum. Particularly the difference between frozen and unfrozen enums. 

While Swift doesn't have a convenient way to represent unfrozen enum types without Library Evolution (something not practical here), we want to be able to offer an escape hatch in generated code while continuing to generate safe and accurate code.

In the linked ticket, we opted to do this by offering the ability to use a `RawRepresentable` struct which would enable characteristics seen below:

> ```swift
> enum MyTypes: String {
>     case foo
>     case bar
> }
> 
> // usage
> 
> switch value {
> case .foo:
>     print("Do foo")
> case .bar:
>     print("Do bar")
> }
> ```
> 
> would become this:
> 
> ```swift
> struct MyTypes: RawRepresentable {
>     let rawValue: String
>     
>     init(rawValue: String) {
>         self.rawValue = rawValue
>     }
> 
>     static let foo = Self(rawValue: "foo")
>     static let bar = Self(rawValue: "bar")
> }
> 
> // usage
> 
> switch value {
> case .foo:
>     print("Do foo")
> case .bar:
>     print("Do bar")
> case MyType(rawValue: "baz"):
>     print("Do undocumented baz")
> default:
>     print("Do something else")
> }
> ```

