### PR TITLE
Remove Module Namespace from References

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -271,7 +271,7 @@ extension Generator {
             }
         }
         name = Template(options.entities.nameTemplate).substitute(name)
-        return .userDefined(name: makeTypeName(name).namespace(context.namespace))
+        return .userDefined(name: makeTypeName(name))
     }
 
     // MARK: - Object


### PR DESCRIPTION
This simply removes the module namespace from also generating with references. However, this _only_ seems to apply to Paths while it generated since only it seemed to inject the namespace into the context.

I noticed this earlier but didn't think anything about it but noticed it again while moving to our new API. Overall, this is just unnecessary and makes things cleaner without breaking anything.

Unless I missed something. I also think that this can be a bit more desirable if they only generate paths but I can't think of a good reason why.

Before:
```swift
public func get(limit: Int32? = nil) -> Request<[TestAPI.Pet]> { ... }
```

Now:
```swift
public func get(limit: Int32? = nil) -> Request<[Pet]> { ... }
```

Tests are not generated. Overall, I think we can take a good look at the overall generation and clean it up a bit.