### PR TITLE
Improve error messages that are used when `oneOf` object decoding fails

### DIFF
--- a/Tests/Support/Snapshots/OctoKit/Sources/Entities/Deployment.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Entities/Deployment.swift
@@ -67,7 +67,10 @@ public struct Deployment: Codable {
             } else if let value = try? container.decode(String.self) {
                 self = .string(value)
             } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Data could not be decoded as any of the expected types ([String: AnyJSON], String)."
+                )
             }
         }
 

--- a/Tests/Support/Snapshots/OctoKit/Sources/Entities/Issue.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Entities/Issue.swift
@@ -125,7 +125,10 @@ public struct Issue: Codable {
             } else if let value = try? container.decode(Object.self) {
                 self = .object(value)
             } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Data could not be decoded as any of the expected types (String, Object)."
+                )
             }
         }
 

--- a/Tests/Support/Snapshots/OctoKit/Sources/Entities/ScimUser.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Entities/ScimUser.swift
@@ -184,7 +184,10 @@ public struct ScimUser: Codable {
                 } else if let value = try? container.decode([AnyJSON].self) {
                     self = .anyJSONs(value)
                 } else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Data could not be decoded as any of the expected types (String, [String: AnyJSON], [AnyJSON])."
+                    )
                 }
             }
 

--- a/Tests/Support/Snapshots/OctoKit/Sources/Entities/ValidationError.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Entities/ValidationError.swift
@@ -31,7 +31,10 @@ public struct ValidationError: Codable {
                 } else if let value = try? container.decode([String].self) {
                     self = .strings(value)
                 } else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Data could not be decoded as any of the expected types (String, Int, [String])."
+                    )
                 }
             }
 

--- a/Tests/Support/Snapshots/OctoKit/Sources/Entities/WebhookConfigInsecureSSL.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Entities/WebhookConfigInsecureSSL.swift
@@ -15,7 +15,10 @@ public enum WebhookConfigInsecureSSL: Codable, Hashable {
         } else if let value = try? container.decode(Double.self) {
             self = .double(value)
         } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Data could not be decoded as any of the expected types (String, Double)."
+            )
         }
     }
 

--- a/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsReposWithOwnerWithRepoContentsWithPath.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsReposWithOwnerWithRepoContentsWithPath.swift
@@ -72,7 +72,10 @@ extension Paths.Repos.WithOwner.WithRepo.Contents {
                 } else if let value = try? container.decode(OctoKit.ContentSubmodule.self) {
                     self = .contentSubmodule(value)
                 } else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Data could not be decoded as any of the expected types ([ContentDirectoryItem], OctoKit.ContentFile, OctoKit.ContentSymlink, OctoKit.ContentSubmodule)."
+                    )
                 }
             }
         }

--- a/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsUser.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsUser.swift
@@ -37,7 +37,10 @@ extension Paths {
                 } else if let value = try? container.decode(OctoKit.PublicUser.self) {
                     self = .publicUser(value)
                 } else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Data could not be decoded as any of the expected types (OctoKit.PrivateUser, OctoKit.PublicUser)."
+                    )
                 }
             }
         }

--- a/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsUsersWithUsername.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Paths/PathsUsersWithUsername.swift
@@ -41,7 +41,10 @@ extension Paths.Users {
                 } else if let value = try? container.decode(OctoKit.PublicUser.self) {
                     self = .publicUser(value)
                 } else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Data could not be decoded as any of the expected types (OctoKit.PrivateUser, OctoKit.PublicUser)."
+                    )
                 }
             }
         }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/AnotherContainer.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/AnotherContainer.swift
@@ -17,14 +17,18 @@ public struct AnotherContainer: Codable {
             }
 
             let container = try decoder.singleValueContainer()
+            let discriminatorValue = try container.decode(Discriminator.self).kind
 
-            switch (try container.decode(Discriminator.self)).kind {
+            switch discriminatorValue {
             case "one": self = .a(try container.decode(A.self))
             case "two": self = .a(try container.decode(A.self))
             case "three": self = .three(try container.decode(Three.self))
 
             default:
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to initialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Discriminator value '\(discriminatorValue)' does not match any expected values (one, two, three)."
+                )
             }
         }
 

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/Container.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/Container.swift
@@ -18,15 +18,19 @@ public struct Container: Codable {
             }
 
             let container = try decoder.singleValueContainer()
+            let discriminatorValue = try container.decode(Discriminator.self).kind
 
-            switch (try container.decode(Discriminator.self)).kind {
+            switch discriminatorValue {
             case "a": self = .a(try container.decode(A.self))
             case "d": self = .a(try container.decode(A.self))
             case "b": self = .b(try container.decode(B.self))
             case "c": self = .c(try container.decode(C.self))
 
             default:
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to initialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Discriminator value '\(discriminatorValue)' does not match any expected values (a, d, b, c)."
+                )
             }
         }
 

--- a/Tests/Support/Snapshots/strip-parent-name-nested-objects-default/Sources/Entities/Container.swift
+++ b/Tests/Support/Snapshots/strip-parent-name-nested-objects-default/Sources/Entities/Container.swift
@@ -20,7 +20,10 @@ public struct Container: Codable {
             } else if let value = try? container.decode(ContainerC.self) {
                 self = .containerC(value)
             } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Data could not be decoded as any of the expected types (ContainerA, ContainerB, ContainerC)."
+                )
             }
         }
 

--- a/Tests/Support/Snapshots/strip-parent-name-nested-objects-enabled/Sources/Entities/Container.swift
+++ b/Tests/Support/Snapshots/strip-parent-name-nested-objects-enabled/Sources/Entities/Container.swift
@@ -20,7 +20,10 @@ public struct Container: Codable {
             } else if let value = try? container.decode(ContainerC.self) {
                 self = .c(value)
             } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to intialize `oneOf`")
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Data could not be decoded as any of the expected types (ContainerA, ContainerB, ContainerC)."
+                )
             }
         }
 


### PR DESCRIPTION
# Background

- #158 

When we faced the linked bug above, it was hard to figure out exactly what was going on at first. The only message that we saw was the following:

> Failed to intialize `oneOf`

It would be nicer if the message logged could help us to understand what has gone on a little more so I have updated it so that it includes more details about the issue. 

You can see the diff of the snapshots for an idea of how this looks. 